### PR TITLE
Introduce pojo builders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `AuthorizedAccessPojo`
   - `BillingCompanyPojo`
   - `BillingTypePojo`
+  - `PersonPojo`
 
 ### Tests
 - CompanyServiceImpl - validate the proper mapping behaviour of method "readDetails"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `ProductCategoryPojo`
   - `ProductListPojo`
   - `SalespersonPojo`
+  - `SellStatusPojo`
   - `ShipperPojo`
   - `UserPojo`
   - `UserRolePojo`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `ImagePojo`
   - `PaymentRedirectionDetailsPojo`
   - `PersonPojo`
+  - `ProductPojo`
   - `ProductCategoryPojo`
   - `ProductListPojo`
   - `SalespersonPojo`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `ProductCategoryPojo`
   - `ProductListPojo`
   - `SalespersonPojo`
+  - `SellDetailPojo`
   - `SellStatusPojo`
   - `ShipperPojo`
   - `UserPojo`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `ProductCategoryPojo`
   - `ProductListPojo`
   - `SalespersonPojo`
+  - `ShipperPojo`
   - `UserPojo`
   - `UserRolePojo`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `ProductCategoryPojo`
   - `ProductListPojo`
   - `SalespersonPojo`
+  - `UserRolePojo`
 
 ### Tests
 - CompanyServiceImpl - validate the proper mapping behaviour of method "readDetails"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update to latest Spring Boot patch (as of Oct 12th, 2022)
   - `spring-boot-starter-parent` - `2.6.4` to `2.6.12`
 - Take advantage of Project Lombok `@Builder` annotation for Pojo classes
-  -  `AddressPojo`
-  -  `AuthorizedAccessPojo`
+  - `AddressPojo`
+  - `AuthorizedAccessPojo`
+  - `BillingCompanyPojo`
 
 ### Tests
 - CompanyServiceImpl - validate the proper mapping behaviour of method "readDetails"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `ProductCategoryPojo`
   - `ProductListPojo`
   - `SalespersonPojo`
+  - `UserPojo`
   - `UserRolePojo`
 
 ### Tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `BillingTypePojo`
   - `CustomerPojo`
   - `ImagePojo`
+  - `PaymentRedirectionDetailsPojo`
   - `PersonPojo`
   - `ProductCategoryPojo`
   - `ProductListPojo`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `PersonPojo`
   - `ProductCategoryPojo`
   - `ProductListPojo`
+  - `SalespersonPojo`
 
 ### Tests
 - CompanyServiceImpl - validate the proper mapping behaviour of method "readDetails"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `BillingCompanyPojo`
   - `BillingTypePojo`
   - `CustomerPojo`
+  - `ImagePojo`
   - `PersonPojo`
 
 ### Tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `ProductCategoryPojo`
   - `ProductListPojo`
   - `SalespersonPojo`
+  - `SellPojo`
   - `SellDetailPojo`
   - `SellStatusPojo`
   - `ShipperPojo`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `ImagePojo`
   - `PersonPojo`
   - `ProductCategoryPojo`
+  - `ProductListPojo`
 
 ### Tests
 - CompanyServiceImpl - validate the proper mapping behaviour of method "readDetails"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `spring-boot-starter-parent` - `2.6.4` to `2.6.12`
 - Take advantage of Project Lombok `@Builder` annotation for Pojo classes
   -  `AddressPojo`
+  -  `AuthorizedAccessPojo`
 
 ### Tests
 - CompanyServiceImpl - validate the proper mapping behaviour of method "readDetails"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `AuthorizedAccessPojo`
   - `BillingCompanyPojo`
   - `BillingTypePojo`
+  - `CustomerPojo`
   - `PersonPojo`
 
 ### Tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `AddressPojo`
   - `AuthorizedAccessPojo`
   - `BillingCompanyPojo`
+  - `BillingTypePojo`
 
 ### Tests
 - CompanyServiceImpl - validate the proper mapping behaviour of method "readDetails"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `app_users_roles_permissions` -> `should be app_user_role_permissions`
 - Update to latest Spring Boot patch (as of Oct 12th, 2022)
   - `spring-boot-starter-parent` - `2.6.4` to `2.6.12`
+- Take advantage of Project Lombok `@Builder` annotation for Pojo classes
+  -  `AddressPojo`
 
 ### Tests
 - CompanyServiceImpl - validate the proper mapping behaviour of method "readDetails"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `CustomerPojo`
   - `ImagePojo`
   - `PersonPojo`
+  - `ProductCategoryPojo`
 
 ### Tests
 - CompanyServiceImpl - validate the proper mapping behaviour of method "readDetails"

--- a/src/main/java/org/trebol/converters/topojo/Address2Pojo.java
+++ b/src/main/java/org/trebol/converters/topojo/Address2Pojo.java
@@ -31,10 +31,11 @@ public class Address2Pojo
 
   @Override
   public AddressPojo convert(Address source) {
-    AddressPojo target = new AddressPojo();
-    target.setCity(source.getCity());
-    target.setMunicipality(source.getMunicipality());
-    target.setFirstLine(source.getFirstLine());
+    AddressPojo target = AddressPojo.builder()
+      .city(source.getCity())
+      .municipality(source.getMunicipality())
+      .firstLine(source.getFirstLine())
+      .build();
     if (source.getSecondLine() != null && !source.getSecondLine().isBlank()) {
       target.setSecondLine(source.getSecondLine());
     }

--- a/src/main/java/org/trebol/converters/topojo/BillingCompany2Pojo.java
+++ b/src/main/java/org/trebol/converters/topojo/BillingCompany2Pojo.java
@@ -31,11 +31,9 @@ public class BillingCompany2Pojo
 
   @Override
   public BillingCompanyPojo convert(BillingCompany source) {
-    BillingCompanyPojo target = new BillingCompanyPojo();
-
-    target.setIdNumber(source.getIdNumber());
-    target.setName(source.getName());
-
-    return target;
+    return BillingCompanyPojo.builder()
+      .idNumber(source.getIdNumber())
+      .name(source.getName())
+      .build();
   }
 }

--- a/src/main/java/org/trebol/converters/topojo/BillingType2Pojo.java
+++ b/src/main/java/org/trebol/converters/topojo/BillingType2Pojo.java
@@ -31,10 +31,8 @@ public class BillingType2Pojo
 
   @Override
   public BillingTypePojo convert(BillingType source) {
-    BillingTypePojo target = new BillingTypePojo();
-
-    target.setName(source.getName());
-
-    return target;
+    return BillingTypePojo.builder()
+      .name(source.getName())
+      .build();
   }
 }

--- a/src/main/java/org/trebol/converters/topojo/Customer2Pojo.java
+++ b/src/main/java/org/trebol/converters/topojo/Customer2Pojo.java
@@ -31,8 +31,8 @@ public class Customer2Pojo
 
   @Override
   public CustomerPojo convert(Customer source) {
-    CustomerPojo target = new CustomerPojo();
-    target.setId(source.getId());
-    return target;
+    return CustomerPojo.builder()
+      .id(source.getId())
+      .build();
   }
 }

--- a/src/main/java/org/trebol/converters/topojo/Image2Pojo.java
+++ b/src/main/java/org/trebol/converters/topojo/Image2Pojo.java
@@ -31,12 +31,12 @@ public class Image2Pojo
 
   @Override
   public ImagePojo convert(Image source) {
-    ImagePojo target = new ImagePojo();
-    target.setId(source.getId());
-    target.setCode(source.getCode());
-    target.setFilename(source.getFilename());
-    target.setUrl(source.getUrl());
-    return target;
+    return ImagePojo.builder()
+      .id(source.getId())
+      .code(source.getCode())
+      .filename(source.getFilename())
+      .url(source.getUrl())
+      .build();
   }
 
 }

--- a/src/main/java/org/trebol/converters/topojo/Person2Pojo.java
+++ b/src/main/java/org/trebol/converters/topojo/Person2Pojo.java
@@ -31,12 +31,13 @@ public class Person2Pojo
 
   @Override
   public PersonPojo convert(Person source) {
-    PersonPojo target = new PersonPojo();
-    target.setId(source.getId());
-    target.setIdNumber(source.getIdNumber());
-    target.setFirstName(source.getFirstName());
-    target.setLastName(source.getLastName());
-    target.setEmail(source.getEmail());
+    PersonPojo target = PersonPojo.builder()
+      .id(source.getId())
+      .idNumber(source.getIdNumber())
+      .firstName(source.getFirstName())
+      .lastName(source.getLastName())
+      .email(source.getEmail())
+      .build();
     if (source.getPhone1() != null) {
       target.setPhone1(source.getPhone1());
     }

--- a/src/main/java/org/trebol/converters/topojo/Product2Pojo.java
+++ b/src/main/java/org/trebol/converters/topojo/Product2Pojo.java
@@ -31,13 +31,13 @@ public class Product2Pojo
 
   @Override
   public ProductPojo convert(Product source) {
-    ProductPojo target = new ProductPojo();
-    target.setId(source.getId());
-    target.setName(source.getName());
-    target.setBarcode(source.getBarcode());
-    target.setPrice(source.getPrice());
-    target.setCurrentStock(source.getStockCurrent());
-    target.setCriticalStock(source.getStockCritical());
-    return target;
+    return ProductPojo.builder()
+      .id(source.getId())
+      .name(source.getName())
+      .barcode(source.getBarcode())
+      .price(source.getPrice())
+      .currentStock(source.getStockCurrent())
+      .criticalStock(source.getStockCritical())
+      .build();
   }
 }

--- a/src/main/java/org/trebol/converters/topojo/ProductCategory2Pojo.java
+++ b/src/main/java/org/trebol/converters/topojo/ProductCategory2Pojo.java
@@ -31,10 +31,10 @@ public class ProductCategory2Pojo
 
   @Override
   public ProductCategoryPojo convert(ProductCategory source) {
-    ProductCategoryPojo target = new ProductCategoryPojo();
-    target.setId(source.getId());
-    target.setCode(source.getCode());
-    target.setName(source.getName());
-    return target;
+    return ProductCategoryPojo.builder()
+      .id(source.getId())
+      .code(source.getCode())
+      .name(source.getName())
+      .build();
   }
 }

--- a/src/main/java/org/trebol/converters/topojo/Salesperson2Pojo.java
+++ b/src/main/java/org/trebol/converters/topojo/Salesperson2Pojo.java
@@ -31,8 +31,8 @@ public class Salesperson2Pojo
 
   @Override
   public SalespersonPojo convert(Salesperson source) {
-    SalespersonPojo target = new SalespersonPojo();
-    target.setId(source.getId());
-    return target;
+    return SalespersonPojo.builder()
+      .id(source.getId())
+      .build();
   }
 }

--- a/src/main/java/org/trebol/converters/topojo/Sell2Pojo.java
+++ b/src/main/java/org/trebol/converters/topojo/Sell2Pojo.java
@@ -31,17 +31,15 @@ public class Sell2Pojo
 
   @Override
   public SellPojo convert(Sell source) {
-    SellPojo target = new SellPojo();
-
-    target.setBuyOrder(source.getId());
-    target.setDate(source.getDate());
-    target.setNetValue(source.getNetValue());
-    target.setTaxValue(source.getTaxesValue());
-    target.setTotalValue(source.getTotalValue());
-    target.setTotalItems(source.getTotalItems());
-    target.setTransportValue(source.getTransportValue());
-    target.setToken(source.getTransactionToken());
-
-    return target;
+    return SellPojo.builder()
+      .buyOrder(source.getId())
+      .date(source.getDate())
+      .netValue(source.getNetValue())
+      .taxValue(source.getTaxesValue())
+      .totalValue(source.getTotalValue())
+      .totalItems(source.getTotalItems())
+      .transportValue(source.getTransportValue())
+      .token(source.getTransactionToken())
+      .build();
   }
 }

--- a/src/main/java/org/trebol/converters/topojo/SellDetail2Pojo.java
+++ b/src/main/java/org/trebol/converters/topojo/SellDetail2Pojo.java
@@ -31,10 +31,10 @@ public class SellDetail2Pojo
 
   @Override
   public SellDetailPojo convert(SellDetail source) {
-    SellDetailPojo target = new SellDetailPojo();
-    target.setId(source.getId());
-    target.setUnits(source.getUnits());
-    target.setDescription(source.getDescription());
-    return target;
+    return SellDetailPojo.builder()
+      .id(source.getId())
+      .units(source.getUnits())
+      .description(source.getDescription())
+      .build();
   }
 }

--- a/src/main/java/org/trebol/converters/topojo/SellStatus2Pojo.java
+++ b/src/main/java/org/trebol/converters/topojo/SellStatus2Pojo.java
@@ -31,9 +31,9 @@ public class SellStatus2Pojo
 
   @Override
   public SellStatusPojo convert(SellStatus source) {
-    SellStatusPojo target = new SellStatusPojo();
-    target.setCode(source.getCode());
-    target.setName(source.getName());
-    return target;
+    return SellStatusPojo.builder()
+      .code(source.getCode())
+      .name(source.getName())
+      .build();
   }
 }

--- a/src/main/java/org/trebol/converters/topojo/Shipper2Pojo.java
+++ b/src/main/java/org/trebol/converters/topojo/Shipper2Pojo.java
@@ -31,11 +31,9 @@ public class Shipper2Pojo
 
   @Override
   public ShipperPojo convert(Shipper source) {
-    ShipperPojo target = new ShipperPojo();
-
-    target.setId(source.getId());
-    target.setName(source.getName());
-
-    return target;
+    return ShipperPojo.builder()
+      .id(source.getId())
+      .name(source.getName())
+      .build();
   }
 }

--- a/src/main/java/org/trebol/converters/topojo/User2Pojo.java
+++ b/src/main/java/org/trebol/converters/topojo/User2Pojo.java
@@ -31,10 +31,10 @@ public class User2Pojo
 
   @Override
   public UserPojo convert(User source) {
-    UserPojo target = new UserPojo();
-    target.setId(source.getId());
-    target.setName(source.getName());
-    target.setRole(source.getUserRole().getName());
-    return target;
+    return UserPojo.builder()
+      .id(source.getId())
+      .name(source.getName())
+      .role(source.getUserRole().getName())
+      .build();
   }
 }

--- a/src/main/java/org/trebol/converters/topojo/UserRole2Pojo.java
+++ b/src/main/java/org/trebol/converters/topojo/UserRole2Pojo.java
@@ -31,9 +31,9 @@ public class UserRole2Pojo
 
   @Override
   public UserRolePojo convert(UserRole source) {
-    UserRolePojo target = new UserRolePojo();
-    target.setId(source.getId());
-    target.setName(source.getName());
-    return target;
+    return UserRolePojo.builder()
+      .id(source.getId())
+      .name(source.getName())
+      .build();
   }
 }

--- a/src/main/java/org/trebol/integration/payments/webpayplus/WebpayplusPaymentServiceImpl.java
+++ b/src/main/java/org/trebol/integration/payments/webpayplus/WebpayplusPaymentServiceImpl.java
@@ -66,10 +66,10 @@ public class WebpayplusPaymentServiceImpl
       WebpayPlusTransactionCreateResponse webpayResponse = webpayTransaction.create(
         buyOrder, sessionId, amount, returnUrl
       );
-      PaymentRedirectionDetailsPojo response = new PaymentRedirectionDetailsPojo();
-      response.setUrl(webpayResponse.getUrl());
-      response.setToken(webpayResponse.getToken());
-      return response;
+      return PaymentRedirectionDetailsPojo.builder()
+        .url(webpayResponse.getUrl())
+        .token(webpayResponse.getToken())
+        .build();
     } catch (TransactionCreateException | IOException exc) {
       logger.error("Exception raised while creating transaction: ", exc);
       throw new PaymentServiceException("Webpay could not create a new transaction");

--- a/src/main/java/org/trebol/jpa/services/conversion/CustomersConverterJpaServiceImpl.java
+++ b/src/main/java/org/trebol/jpa/services/conversion/CustomersConverterJpaServiceImpl.java
@@ -44,11 +44,11 @@ public class CustomersConverterJpaServiceImpl
   @Override
   @Nullable
   public CustomerPojo convertToPojo(Customer source) {
-    CustomerPojo target = new CustomerPojo();
-    target.setId(source.getId());
     PersonPojo targetPerson = peopleService.convertToPojo(source.getPerson());
-    target.setPerson(targetPerson);
-    return target;
+    return CustomerPojo.builder()
+      .id(source.getId())
+      .person(targetPerson)
+      .build();
   }
 
   @Override

--- a/src/main/java/org/trebol/jpa/services/conversion/ProductListConverterJpaServiceImpl.java
+++ b/src/main/java/org/trebol/jpa/services/conversion/ProductListConverterJpaServiceImpl.java
@@ -44,7 +44,12 @@ public class ProductListConverterJpaServiceImpl
   public ProductListPojo convertToPojo(ProductList source) {
     Long sourceListId = source.getId();
     long itemCount = productListItemRepository.count(QProductListItem.productListItem.list.id.eq(sourceListId));
-    return new ProductListPojo(sourceListId, source.getName(), source.getCode(), itemCount);
+    return ProductListPojo.builder()
+      .id(sourceListId)
+      .name(source.getName())
+      .code(source.getCode())
+      .totalCount(itemCount)
+      .build();
   }
 
   @Override

--- a/src/main/java/org/trebol/jpa/services/conversion/SalespeopleConverterJpaServiceImpl.java
+++ b/src/main/java/org/trebol/jpa/services/conversion/SalespeopleConverterJpaServiceImpl.java
@@ -44,11 +44,11 @@ public class SalespeopleConverterJpaServiceImpl
   @Override
   @Nullable
   public SalespersonPojo convertToPojo(Salesperson source) {
-    SalespersonPojo target = new SalespersonPojo();
-    target.setId(source.getId());
     PersonPojo targetPerson = peopleService.convertToPojo(source.getPerson());
-    target.setPerson(targetPerson);
-    return target;
+    return SalespersonPojo.builder()
+      .id(source.getId())
+      .person(targetPerson)
+      .build();
   }
 
   @Override

--- a/src/main/java/org/trebol/jpa/services/conversion/UsersConverterJpaServiceImpl.java
+++ b/src/main/java/org/trebol/jpa/services/conversion/UsersConverterJpaServiceImpl.java
@@ -72,10 +72,11 @@ public class UsersConverterJpaServiceImpl
   @Override
   @Nullable
   public UserPojo convertToPojo(User source) {
-    UserPojo target = new UserPojo();
-    target.setId(source.getId());
-    target.setName(source.getName());
-    target.setRole(source.getUserRole().getName());
+    UserPojo target = UserPojo.builder()
+      .id(source.getId())
+      .name(source.getName())
+      .role(source.getUserRole().getName())
+      .build();
 
     Person sourcePerson = source.getPerson();
     if (sourcePerson != null) {

--- a/src/main/java/org/trebol/jpa/services/crud/SalesJpaCrudServiceImpl.java
+++ b/src/main/java/org/trebol/jpa/services/crud/SalesJpaCrudServiceImpl.java
@@ -137,12 +137,13 @@ public class SalesJpaCrudServiceImpl
       List<SellDetailPojo> sellDetails = new ArrayList<>();
       for (SellDetail sourceSellDetail : details) {
         ProductPojo product = productConverter.convertToPojo(sourceSellDetail.getProduct());
-        SellDetailPojo targetSellDetail = new SellDetailPojo();
-        targetSellDetail.setId(sourceSellDetail.getId());
-        targetSellDetail.setUnitValue(sourceSellDetail.getUnitValue());
-        targetSellDetail.setUnits(sourceSellDetail.getUnits());
-        targetSellDetail.setProduct(product);
-        targetSellDetail.setDescription(sourceSellDetail.getDescription());
+        SellDetailPojo targetSellDetail = SellDetailPojo.builder()
+          .id(sourceSellDetail.getId())
+          .unitValue(sourceSellDetail.getUnitValue())
+          .units(sourceSellDetail.getUnits())
+          .product(product)
+          .description(sourceSellDetail.getDescription())
+          .build();
         sellDetails.add(targetSellDetail);
       }
       target.setDetails(sellDetails);

--- a/src/main/java/org/trebol/operation/controllers/AccessController.java
+++ b/src/main/java/org/trebol/operation/controllers/AccessController.java
@@ -74,9 +74,9 @@ public class AccessController {
       throw new IllegalStateException("");
     }
     Collection<String> routes = authorizedApiService.getAuthorizedApiRoutes(userDetails);
-    AuthorizedAccessPojo target = new AuthorizedAccessPojo();
-    target.setRoutes(routes);
-    return target;
+    return AuthorizedAccessPojo.builder()
+      .routes(routes)
+      .build();
   }
 
   @GetMapping({"/{apiRoute}", "/{apiRoute}/"})
@@ -89,9 +89,9 @@ public class AccessController {
       return null;
     }
     Collection<String> permissions = authorizedApiService.getAuthorizedApiRouteAccess(userDetails, apiRoute);
-    AuthorizedAccessPojo target = new AuthorizedAccessPojo();
-    target.setPermissions(permissions);
-    return target;
+    return AuthorizedAccessPojo.builder()
+      .permissions(permissions)
+      .build();
   }
 
   @ResponseStatus(UNAUTHORIZED)

--- a/src/main/java/org/trebol/operation/services/ReceiptServiceImpl.java
+++ b/src/main/java/org/trebol/operation/services/ReceiptServiceImpl.java
@@ -67,9 +67,7 @@ public class ReceiptServiceImpl
         ReceiptDetailPojo targetDetail = conversionService.convert(d, ReceiptDetailPojo.class);
         if (targetDetail != null) {
           Product pd = d.getProduct();
-          ProductPojo targetDetailProduct = new ProductPojo();
-          targetDetailProduct.setName(pd.getName());
-          targetDetailProduct.setBarcode(pd.getBarcode());
+          ProductPojo targetDetailProduct = ProductPojo.builder().name(pd.getName()).barcode(pd.getBarcode()).build();
           targetDetail.setProduct(targetDetailProduct);
           targetDetail.setUnitValue(d.getUnitValue());
           targetDetails.add(targetDetail);

--- a/src/main/java/org/trebol/operation/services/SalesProcessServiceImpl.java
+++ b/src/main/java/org/trebol/operation/services/SalesProcessServiceImpl.java
@@ -150,10 +150,12 @@ public class SalesProcessServiceImpl
     List<SellDetailPojo> pojoDetails = new ArrayList<>();
     for (SellDetail detail : sellDetailsRepository.findBySellId(existingSell.getId())) {
       ProductPojo productPojo = productConverterService.convertToPojo(detail.getProduct());
-      SellDetailPojo sellDetailPojo = new SellDetailPojo(detail.getId(),
-                                                         detail.getUnits(),
-                                                         detail.getUnitValue(),
-                                                         productPojo);
+      SellDetailPojo sellDetailPojo = SellDetailPojo.builder()
+        .id(detail.getId())
+        .units(detail.getUnits())
+        .unitValue(detail.getUnitValue())
+        .product(productPojo)
+        .build();
       pojoDetails.add(sellDetailPojo);
     }
     target.setStatus(SELL_STATUS_PAID_UNCONFIRMED);
@@ -182,10 +184,12 @@ public class SalesProcessServiceImpl
     List<SellDetailPojo> pojoDetails = new ArrayList<>();
     for (SellDetail detail : sellDetailsRepository.findBySellId(existingSell.getId())) {
       ProductPojo productPojo = productConverterService.convertToPojo(detail.getProduct());
-      SellDetailPojo sellDetailPojo = new SellDetailPojo(detail.getId(),
-                                                         detail.getUnits(),
-                                                         detail.getUnitValue(),
-                                                         productPojo);
+      SellDetailPojo sellDetailPojo = SellDetailPojo.builder()
+        .id(detail.getId())
+        .units(detail.getUnits())
+        .unitValue(detail.getUnitValue())
+        .product(productPojo)
+        .build();
       pojoDetails.add(sellDetailPojo);
     }
     target.setDetails(pojoDetails);
@@ -215,10 +219,12 @@ public class SalesProcessServiceImpl
     List<SellDetailPojo> pojoDetails = new ArrayList<>();
     for (SellDetail detail : sellDetailsRepository.findBySellId(existingSell.getId())) {
       ProductPojo productPojo = productConverterService.convertToPojo(detail.getProduct());
-      SellDetailPojo sellDetailPojo = new SellDetailPojo(detail.getId(),
-                                                         detail.getUnits(),
-                                                         detail.getUnitValue(),
-                                                         productPojo);
+      SellDetailPojo sellDetailPojo = SellDetailPojo.builder()
+        .id(detail.getId())
+        .units(detail.getUnits())
+        .unitValue(detail.getUnitValue())
+        .product(productPojo)
+        .build();
       pojoDetails.add(sellDetailPojo);
     }
     target.setDetails(pojoDetails);
@@ -247,10 +253,12 @@ public class SalesProcessServiceImpl
     List<SellDetailPojo> pojoDetails = new ArrayList<>();
     for (SellDetail detail : sellDetailsRepository.findBySellId(existingSell.getId())) {
       ProductPojo productPojo = productConverterService.convertToPojo(detail.getProduct());
-      SellDetailPojo sellDetailPojo = new SellDetailPojo(detail.getId(),
-                                                         detail.getUnits(),
-                                                         detail.getUnitValue(),
-                                                         productPojo);
+      SellDetailPojo sellDetailPojo = SellDetailPojo.builder()
+        .id(detail.getId())
+        .units(detail.getUnits())
+        .unitValue(detail.getUnitValue())
+        .product(productPojo)
+        .build();
       pojoDetails.add(sellDetailPojo);
     }
     target.setDetails(pojoDetails);

--- a/src/main/java/org/trebol/pojo/AddressPojo.java
+++ b/src/main/java/org/trebol/pojo/AddressPojo.java
@@ -41,4 +41,6 @@ public class AddressPojo {
   private String city;
   private String postalCode;
   private String notes;
+
+  public AddressPojo() {}
 }

--- a/src/main/java/org/trebol/pojo/AddressPojo.java
+++ b/src/main/java/org/trebol/pojo/AddressPojo.java
@@ -21,6 +21,7 @@
 package org.trebol.pojo;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
 import lombok.Data;
 
 import javax.validation.constraints.NotBlank;
@@ -28,6 +29,7 @@ import javax.validation.constraints.NotBlank;
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
 
 @Data
+@Builder
 @JsonInclude(NON_EMPTY)
 public class AddressPojo {
   @NotBlank
@@ -39,6 +41,4 @@ public class AddressPojo {
   private String city;
   private String postalCode;
   private String notes;
-
-  public AddressPojo() { }
 }

--- a/src/main/java/org/trebol/pojo/AddressPojo.java
+++ b/src/main/java/org/trebol/pojo/AddressPojo.java
@@ -41,6 +41,4 @@ public class AddressPojo {
   private String city;
   private String postalCode;
   private String notes;
-
-  public AddressPojo() {}
 }

--- a/src/main/java/org/trebol/pojo/AuthorizedAccessPojo.java
+++ b/src/main/java/org/trebol/pojo/AuthorizedAccessPojo.java
@@ -34,6 +34,4 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 public class AuthorizedAccessPojo {
   private Collection<String> routes;
   private Collection<String> permissions;
-
-  public AuthorizedAccessPojo() {}
 }

--- a/src/main/java/org/trebol/pojo/AuthorizedAccessPojo.java
+++ b/src/main/java/org/trebol/pojo/AuthorizedAccessPojo.java
@@ -34,4 +34,6 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 public class AuthorizedAccessPojo {
   private Collection<String> routes;
   private Collection<String> permissions;
+
+  public AuthorizedAccessPojo() {}
 }

--- a/src/main/java/org/trebol/pojo/AuthorizedAccessPojo.java
+++ b/src/main/java/org/trebol/pojo/AuthorizedAccessPojo.java
@@ -21,6 +21,7 @@
 package org.trebol.pojo;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
 import lombok.Data;
 
 import java.util.Collection;
@@ -28,6 +29,7 @@ import java.util.Collection;
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 @Data
+@Builder
 @JsonInclude(NON_NULL)
 public class AuthorizedAccessPojo {
   private Collection<String> routes;

--- a/src/main/java/org/trebol/pojo/BillingCompanyPojo.java
+++ b/src/main/java/org/trebol/pojo/BillingCompanyPojo.java
@@ -21,17 +21,13 @@
 package org.trebol.pojo;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
 import lombok.Data;
 
 @Data
+@Builder
 @JsonInclude
 public class BillingCompanyPojo {
   private String idNumber;
   private String name;
-
-  public BillingCompanyPojo() { }
-
-  public BillingCompanyPojo(String idNumber) {
-    this.idNumber = idNumber;
-  }
 }

--- a/src/main/java/org/trebol/pojo/BillingCompanyPojo.java
+++ b/src/main/java/org/trebol/pojo/BillingCompanyPojo.java
@@ -30,6 +30,4 @@ import lombok.Data;
 public class BillingCompanyPojo {
   private String idNumber;
   private String name;
-
-  public BillingCompanyPojo() {}
 }

--- a/src/main/java/org/trebol/pojo/BillingCompanyPojo.java
+++ b/src/main/java/org/trebol/pojo/BillingCompanyPojo.java
@@ -30,4 +30,6 @@ import lombok.Data;
 public class BillingCompanyPojo {
   private String idNumber;
   private String name;
+
+  public BillingCompanyPojo() {}
 }

--- a/src/main/java/org/trebol/pojo/BillingTypePojo.java
+++ b/src/main/java/org/trebol/pojo/BillingTypePojo.java
@@ -34,4 +34,6 @@ public class BillingTypePojo {
   @NotBlank
   @NonNull
   private String name;
+
+  public BillingTypePojo() {}
 }

--- a/src/main/java/org/trebol/pojo/BillingTypePojo.java
+++ b/src/main/java/org/trebol/pojo/BillingTypePojo.java
@@ -34,6 +34,4 @@ public class BillingTypePojo {
   @NotBlank
   @NonNull
   private String name;
-
-  public BillingTypePojo() {}
 }

--- a/src/main/java/org/trebol/pojo/BillingTypePojo.java
+++ b/src/main/java/org/trebol/pojo/BillingTypePojo.java
@@ -21,21 +21,17 @@
 package org.trebol.pojo;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NonNull;
 
 import javax.validation.constraints.NotBlank;
 
 @Data
+@Builder
 @JsonInclude
 public class BillingTypePojo {
   @NotBlank
   @NonNull
   private String name;
-
-  public BillingTypePojo() {}
-
-  public BillingTypePojo(@NonNull String name) {
-    this.name = name;
-  }
 }

--- a/src/main/java/org/trebol/pojo/CustomerPojo.java
+++ b/src/main/java/org/trebol/pojo/CustomerPojo.java
@@ -22,12 +22,14 @@ package org.trebol.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
 import lombok.Data;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
 @Data
+@Builder
 @JsonInclude
 public class CustomerPojo {
   @JsonIgnore
@@ -35,14 +37,4 @@ public class CustomerPojo {
   @NotNull
   @Valid
   private PersonPojo person;
-
-  public CustomerPojo() { }
-
-  public CustomerPojo(String idNumber) {
-    this.person = PersonPojo.builder().idNumber(idNumber).build();
-  }
-
-  public CustomerPojo(PersonPojo person) {
-    this.person = person;
-  }
 }

--- a/src/main/java/org/trebol/pojo/CustomerPojo.java
+++ b/src/main/java/org/trebol/pojo/CustomerPojo.java
@@ -39,7 +39,7 @@ public class CustomerPojo {
   public CustomerPojo() { }
 
   public CustomerPojo(String idNumber) {
-    this.person = new PersonPojo(idNumber);
+    this.person = PersonPojo.builder().idNumber(idNumber).build();
   }
 
   public CustomerPojo(PersonPojo person) {

--- a/src/main/java/org/trebol/pojo/ImagePojo.java
+++ b/src/main/java/org/trebol/pojo/ImagePojo.java
@@ -22,6 +22,7 @@ package org.trebol.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
 import lombok.Data;
 
 import javax.validation.constraints.NotBlank;
@@ -29,6 +30,7 @@ import javax.validation.constraints.NotBlank;
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 @Data
+@Builder
 @JsonInclude(NON_NULL)
 public class ImagePojo {
   @JsonIgnore
@@ -39,23 +41,4 @@ public class ImagePojo {
   private String filename;
   @NotBlank
   private String url;
-
-  public ImagePojo() { }
-
-  public ImagePojo(String filename) {
-    this.filename = filename;
-  }
-
-  public ImagePojo(String code, String filename, String url) {
-    this.code = code;
-    this.filename = filename;
-    this.url = url;
-  }
-
-  public ImagePojo(Long id, String code, String filename, String url) {
-    this.id = id;
-    this.code = code;
-    this.filename = filename;
-    this.url = url;
-  }
 }

--- a/src/main/java/org/trebol/pojo/PaymentRedirectionDetailsPojo.java
+++ b/src/main/java/org/trebol/pojo/PaymentRedirectionDetailsPojo.java
@@ -21,21 +21,16 @@
 package org.trebol.pojo;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
 import lombok.Data;
 
 /**
  * Wrapper class for data needed to redirect towards payment page
  */
 @Data
+@Builder
 @JsonInclude
 public class PaymentRedirectionDetailsPojo {
   private String url;
   private String token;
-
-  public PaymentRedirectionDetailsPojo() { }
-
-  public PaymentRedirectionDetailsPojo(String url, String token) {
-    this.url = url;
-    this.token = token;
-  }
 }

--- a/src/main/java/org/trebol/pojo/PersonPojo.java
+++ b/src/main/java/org/trebol/pojo/PersonPojo.java
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotBlank;
 

--- a/src/main/java/org/trebol/pojo/PersonPojo.java
+++ b/src/main/java/org/trebol/pojo/PersonPojo.java
@@ -22,13 +22,16 @@ package org.trebol.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotBlank;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 @Data
+@Builder
 @JsonInclude(NON_NULL)
 public class PersonPojo {
   @JsonIgnore
@@ -46,27 +49,5 @@ public class PersonPojo {
   // @Pattern(regexp = "^(((\\(\\+?[0-9]{3}\\))|(\\+?[0-9]{3})) ?)?[0-9]{3,4}[ -]?[0-9]{4}$")
   private String phone2;
 
-  public PersonPojo() { }
-
-  public PersonPojo(String idNumber) {
-    this.idNumber = idNumber;
-  }
-
-  public PersonPojo(String firstName, String lastName, String idNumber, String email) {
-    this.firstName = firstName;
-    this.lastName = lastName;
-    this.idNumber = idNumber;
-    this.email = email;
-  }
-
-  public PersonPojo(Long id, String firstName, String lastName, String idNumber, String email, String phone1,
-                    String phone2) {
-    this.id = id;
-    this.firstName = firstName;
-    this.lastName = lastName;
-    this.idNumber = idNumber;
-    this.email = email;
-    this.phone1 = phone1;
-    this.phone2 = phone2;
-  }
+  public PersonPojo() {}
 }

--- a/src/main/java/org/trebol/pojo/PersonPojo.java
+++ b/src/main/java/org/trebol/pojo/PersonPojo.java
@@ -48,6 +48,4 @@ public class PersonPojo {
   private String phone1;
   // @Pattern(regexp = "^(((\\(\\+?[0-9]{3}\\))|(\\+?[0-9]{3})) ?)?[0-9]{3,4}[ -]?[0-9]{4}$")
   private String phone2;
-
-  public PersonPojo() {}
 }

--- a/src/main/java/org/trebol/pojo/ProductCategoryPojo.java
+++ b/src/main/java/org/trebol/pojo/ProductCategoryPojo.java
@@ -22,6 +22,7 @@ package org.trebol.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
 import lombok.Data;
 
 import javax.validation.constraints.NotBlank;
@@ -29,6 +30,7 @@ import javax.validation.constraints.NotBlank;
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 @Data
+@Builder
 @JsonInclude
 public class ProductCategoryPojo {
   @JsonIgnore
@@ -39,23 +41,4 @@ public class ProductCategoryPojo {
   private String name;
   @JsonInclude(NON_NULL)
   private ProductCategoryPojo parent;
-
-  public ProductCategoryPojo() { }
-
-  public ProductCategoryPojo(String code) {
-    this.code = code;
-  }
-
-  public ProductCategoryPojo(String code, String name, ProductCategoryPojo parent) {
-    this.code = code;
-    this.name = name;
-    this.parent = parent;
-  }
-
-  public ProductCategoryPojo(Long id, String code, String name, ProductCategoryPojo parent) {
-    this.id = id;
-    this.code = code;
-    this.name = name;
-    this.parent = parent;
-  }
 }

--- a/src/main/java/org/trebol/pojo/ProductListPojo.java
+++ b/src/main/java/org/trebol/pojo/ProductListPojo.java
@@ -22,6 +22,7 @@ package org.trebol.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
 import lombok.Data;
 
 import javax.validation.constraints.NotEmpty;
@@ -30,6 +31,7 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_DEFAULT;
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 @Data
+@Builder
 @JsonInclude(NON_NULL)
 public class ProductListPojo {
   @JsonIgnore
@@ -39,17 +41,4 @@ public class ProductListPojo {
   private String code;
   @JsonInclude(NON_DEFAULT)
   private long totalCount;
-
-  public ProductListPojo() { }
-
-  public ProductListPojo(String code) {
-    this.code = code;
-  }
-
-  public ProductListPojo(Long id, String name, String code, long totalCount) {
-    this.id = id;
-    this.name = name;
-    this.code = code;
-    this.totalCount = totalCount;
-  }
 }

--- a/src/main/java/org/trebol/pojo/ProductPojo.java
+++ b/src/main/java/org/trebol/pojo/ProductPojo.java
@@ -22,6 +22,7 @@ package org.trebol.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
 import lombok.Data;
 
 import javax.validation.constraints.NotBlank;
@@ -32,6 +33,7 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 @Data
+@Builder
 @JsonInclude(NON_NULL)
 public class ProductPojo {
   @JsonIgnore
@@ -50,30 +52,4 @@ public class ProductPojo {
   private Integer criticalStock;
   private ProductCategoryPojo category;
   private Collection<ImagePojo> images;
-
-  public ProductPojo() { }
-
-  public ProductPojo(String barcode) {
-    this.barcode = barcode;
-  }
-
-  public ProductPojo(Long id,
-                     String name,
-                     String barcode,
-                     String description,
-                     Integer price,
-                     Integer currentStock,
-                     Integer criticalStock,
-                     ProductCategoryPojo category,
-                     Collection<ImagePojo> images) {
-    this.id = id;
-    this.name = name;
-    this.barcode = barcode;
-    this.description = description;
-    this.price = price;
-    this.currentStock = currentStock;
-    this.criticalStock = criticalStock;
-    this.category = category;
-    this.images = images;
-  }
 }

--- a/src/main/java/org/trebol/pojo/SalespersonPojo.java
+++ b/src/main/java/org/trebol/pojo/SalespersonPojo.java
@@ -39,7 +39,7 @@ public class SalespersonPojo {
   public SalespersonPojo() { }
 
   public SalespersonPojo(String idNumber) {
-    this.person = new PersonPojo(idNumber);
+    this.person = PersonPojo.builder().idNumber(idNumber).build();
   }
 
   public SalespersonPojo(PersonPojo person) {

--- a/src/main/java/org/trebol/pojo/SalespersonPojo.java
+++ b/src/main/java/org/trebol/pojo/SalespersonPojo.java
@@ -22,12 +22,14 @@ package org.trebol.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
 import lombok.Data;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
 @Data
+@Builder
 @JsonInclude
 public class SalespersonPojo {
   @JsonIgnore
@@ -35,14 +37,4 @@ public class SalespersonPojo {
   @NotNull
   @Valid
   private PersonPojo person;
-
-  public SalespersonPojo() { }
-
-  public SalespersonPojo(String idNumber) {
-    this.person = PersonPojo.builder().idNumber(idNumber).build();
-  }
-
-  public SalespersonPojo(PersonPojo person) {
-    this.person = person;
-  }
 }

--- a/src/main/java/org/trebol/pojo/SellDetailPojo.java
+++ b/src/main/java/org/trebol/pojo/SellDetailPojo.java
@@ -22,12 +22,14 @@ package org.trebol.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
 import lombok.Data;
 
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 @Data
+@Builder
 @JsonInclude
 public class SellDetailPojo {
   @JsonIgnore
@@ -38,18 +40,4 @@ public class SellDetailPojo {
   private String description;
   @NotNull
   private ProductPojo product;
-
-  public SellDetailPojo() { }
-
-  public SellDetailPojo(int units, ProductPojo product) {
-    this.units = units;
-    this.product = product;
-  }
-
-  public SellDetailPojo(Long id, int units, int unitValue, ProductPojo product) {
-    this.id = id;
-    this.units = units;
-    this.unitValue = unitValue;
-    this.product = product;
-  }
 }

--- a/src/main/java/org/trebol/pojo/SellPojo.java
+++ b/src/main/java/org/trebol/pojo/SellPojo.java
@@ -23,6 +23,7 @@ package org.trebol.pojo;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
 import lombok.Data;
 
 import javax.validation.Valid;
@@ -35,6 +36,7 @@ import static com.fasterxml.jackson.annotation.JsonFormat.Shape.STRING;
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
 
 @Data
+@Builder
 @JsonInclude
 public class SellPojo {
   private Long buyOrder;
@@ -62,62 +64,4 @@ public class SellPojo {
   private BillingCompanyPojo billingCompany;
   private AddressPojo billingAddress;
   private AddressPojo shippingAddress;
-
-  public SellPojo() { }
-
-  public SellPojo(Long buyOrder, String token, Instant date, Collection<SellDetailPojo> details, int netValue,
-                  int taxValue, int transportValue, int totalValue, int totalItems, String status, String billingType,
-                  String paymentType, CustomerPojo customer, SalespersonPojo salesperson, ShipperPojo shipper,
-                  BillingCompanyPojo billingCompany, AddressPojo billingAddress, AddressPojo shippingAddress) {
-    this.buyOrder = buyOrder;
-    this.token = token;
-    this.date = date;
-    this.details = details;
-    this.netValue = netValue;
-    this.taxValue = taxValue;
-    this.transportValue = transportValue;
-    this.totalValue = totalValue;
-    this.totalItems = totalItems;
-    this.status = status;
-    this.billingType = billingType;
-    this.paymentType = paymentType;
-    this.customer = customer;
-    this.salesperson = salesperson;
-    this.shipper = shipper;
-    this.billingCompany = billingCompany;
-    this.billingAddress = billingAddress;
-    this.shippingAddress = shippingAddress;
-  }
-
-  public SellPojo(SellPojo source) {
-    this.buyOrder = source.buyOrder;
-    this.token = source.token;
-    this.date = source.date;
-    this.details = source.details;
-    this.netValue = source.netValue;
-    this.taxValue = source.taxValue;
-    this.transportValue = source.transportValue;
-    this.totalValue = source.totalValue;
-    this.totalItems = source.totalItems;
-    this.status = source.status;
-    this.billingType = source.billingType;
-    this.paymentType = source.paymentType;
-    this.customer = source.customer;
-    this.salesperson = source.salesperson;
-    this.shipper = source.shipper;
-    this.billingCompany = source.billingCompany;
-    this.billingAddress = source.billingAddress;
-    this.shippingAddress = source.shippingAddress;
-  }
-
-  public SellPojo(Long buyOrder) {
-    this.buyOrder = buyOrder;
-  }
-
-  public SellPojo(Collection<SellDetailPojo> details, String billingType, String paymentType, CustomerPojo customer) {
-    this.details = details;
-    this.billingType = billingType;
-    this.paymentType = paymentType;
-    this.customer = customer;
-  }
 }

--- a/src/main/java/org/trebol/pojo/SellStatusPojo.java
+++ b/src/main/java/org/trebol/pojo/SellStatusPojo.java
@@ -21,6 +21,7 @@
 package org.trebol.pojo;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
 import lombok.Data;
 
 import javax.validation.constraints.NotBlank;
@@ -28,6 +29,7 @@ import javax.validation.constraints.NotBlank;
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
 
 @Data
+@Builder
 @JsonInclude
 public class SellStatusPojo {
   @NotBlank
@@ -35,10 +37,4 @@ public class SellStatusPojo {
   @JsonInclude(NON_EMPTY)
   @NotBlank
   private String name;
-
-  public SellStatusPojo() { }
-
-  public SellStatusPojo(String name) {
-    this.name = name;
-  }
 }

--- a/src/main/java/org/trebol/pojo/ShipperPojo.java
+++ b/src/main/java/org/trebol/pojo/ShipperPojo.java
@@ -22,21 +22,17 @@ package org.trebol.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
 import lombok.Data;
 
 import javax.validation.constraints.NotBlank;
 
 @Data
+@Builder
 @JsonInclude
 public class ShipperPojo {
   @JsonIgnore
   private Long id;
   @NotBlank
   private String name;
-
-  public ShipperPojo() { }
-
-  public ShipperPojo(String name) {
-    this.name = name;
-  }
 }

--- a/src/main/java/org/trebol/pojo/UserPojo.java
+++ b/src/main/java/org/trebol/pojo/UserPojo.java
@@ -22,6 +22,7 @@ package org.trebol.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
 import lombok.Data;
 
 import javax.validation.constraints.NotBlank;
@@ -29,6 +30,7 @@ import javax.validation.constraints.NotBlank;
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 @Data
+@Builder
 @JsonInclude(NON_NULL)
 public class UserPojo {
   @JsonIgnore
@@ -40,10 +42,4 @@ public class UserPojo {
   private String password;
   private PersonPojo person;
   private String role;
-
-  public UserPojo() { }
-
-  public UserPojo(String name) {
-    this.name = name;
-  }
 }

--- a/src/main/java/org/trebol/pojo/UserRolePojo.java
+++ b/src/main/java/org/trebol/pojo/UserRolePojo.java
@@ -22,21 +22,17 @@ package org.trebol.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
 import lombok.Data;
 
 import javax.validation.constraints.NotNull;
 
 @Data
+@Builder
 @JsonInclude
 public class UserRolePojo {
   @JsonIgnore
   private Long id;
   @NotNull
   private String name;
-
-  public UserRolePojo() { }
-
-  public UserRolePojo(String name) {
-    this.name = name;
-  }
 }

--- a/src/main/java/org/trebol/security/JwtGuestAuthenticationFilter.java
+++ b/src/main/java/org/trebol/security/JwtGuestAuthenticationFilter.java
@@ -79,8 +79,7 @@ public class JwtGuestAuthenticationFilter
 
   private void saveCustomerData(PersonPojo guestData) throws BadInputException {
     try {
-      CustomerPojo targetCustomer = new CustomerPojo();
-      targetCustomer.setPerson(guestData);
+      CustomerPojo targetCustomer = CustomerPojo.builder().person(guestData).build();
       customersService.create(targetCustomer);
     } catch (EntityExistsException e) {
       myLogger.info("Guest with idNumber={} is already registered in the database", guestData.getIdNumber());

--- a/src/test/java/org/trebol/jpa/services/conversion/BillingCompaniesConverterJpaServiceImplTest.java
+++ b/src/test/java/org/trebol/jpa/services/conversion/BillingCompaniesConverterJpaServiceImplTest.java
@@ -38,9 +38,10 @@ class BillingCompaniesConverterJpaServiceImplTest {
         billingCompany.setId(1L);
         billingCompany.setIdNumber(ANY);
 
-        billingCompanyPojo = new BillingCompanyPojo();
-        billingCompanyPojo.setIdNumber(ANY);
-        billingCompanyPojo.setName(ANY);
+        billingCompanyPojo = BillingCompanyPojo.builder()
+          .idNumber(ANY)
+          .name(ANY)
+          .build();
     }
 
     @AfterEach

--- a/src/test/java/org/trebol/jpa/services/conversion/BillingTypesConverterJpaServiceImplTest.java
+++ b/src/test/java/org/trebol/jpa/services/conversion/BillingTypesConverterJpaServiceImplTest.java
@@ -39,8 +39,9 @@ class BillingTypesConverterJpaServiceImplTest {
         billingType.setId(1L);
         billingType.setName(ANY);
 
-        billingTypePojo = new BillingTypePojo();
-        billingTypePojo.setName(ANY);
+        billingTypePojo = BillingTypePojo.builder()
+          .name(ANY)
+          .build();
     }
 
     @AfterEach

--- a/src/test/java/org/trebol/jpa/services/conversion/CustomersConverterJpaServiceImplTest.java
+++ b/src/test/java/org/trebol/jpa/services/conversion/CustomersConverterJpaServiceImplTest.java
@@ -36,8 +36,7 @@ class CustomersConverterJpaServiceImplTest {
 
     @BeforeEach
     void beforeEach() {
-        personPojo = new PersonPojo();
-        personPojo.setId(ID_1L);
+        personPojo = PersonPojo.builder().id(ID_1L).build();
         person = new Person();
         person.setId(ID_1L);
         customer = new Customer();

--- a/src/test/java/org/trebol/jpa/services/conversion/CustomersConverterJpaServiceImplTest.java
+++ b/src/test/java/org/trebol/jpa/services/conversion/CustomersConverterJpaServiceImplTest.java
@@ -43,8 +43,7 @@ class CustomersConverterJpaServiceImplTest {
         customer.setId(ID_1L);
         customer.setPerson(person);
 
-        customerPojo = new CustomerPojo();
-        customerPojo.setPerson(personPojo);
+        customerPojo = CustomerPojo.builder().person(personPojo).build();
     }
 
 

--- a/src/test/java/org/trebol/jpa/services/conversion/ImagesConverterJpaServiceImplTest.java
+++ b/src/test/java/org/trebol/jpa/services/conversion/ImagesConverterJpaServiceImplTest.java
@@ -38,9 +38,10 @@ class ImagesConverterJpaServiceImplTest {
         image.setId(1L);
         image.setFilename(ANY);
 
-        imagePojo = new ImagePojo();
-        imagePojo.setId(1L);
-        imagePojo.setFilename(ANY);
+        imagePojo = ImagePojo.builder()
+          .id(1L)
+          .filename(ANY)
+          .build();
     }
 
     @AfterEach

--- a/src/test/java/org/trebol/jpa/services/conversion/PeopleConverterJpaServiceImplTest.java
+++ b/src/test/java/org/trebol/jpa/services/conversion/PeopleConverterJpaServiceImplTest.java
@@ -36,8 +36,7 @@ class PeopleConverterJpaServiceImplTest {
         person = new Person();
         person.setId(1L);
 
-        personPojo = new PersonPojo();
-        personPojo.setId(1L);
+        personPojo = PersonPojo.builder().id(1L).build();
     }
 
     @AfterEach

--- a/src/test/java/org/trebol/jpa/services/conversion/ProductCategoriesConverterJpaServiceImplTest.java
+++ b/src/test/java/org/trebol/jpa/services/conversion/ProductCategoriesConverterJpaServiceImplTest.java
@@ -42,10 +42,11 @@ public class ProductCategoriesConverterJpaServiceImplTest {
         productCategory = new ProductCategory();
         productCategory.setId(ID_1L);
 
-        productCategoryPojo = new ProductCategoryPojo();
-        productCategoryPojo.setId(ID_1L);
-        productCategoryPojo.setName(ANY);
-        productCategoryPojo.setCode(ANY);
+        productCategoryPojo = ProductCategoryPojo.builder()
+          .id(ID_1L)
+          .name(ANY)
+          .code(ANY)
+          .build();
     }
 
     @AfterEach
@@ -78,13 +79,11 @@ public class ProductCategoriesConverterJpaServiceImplTest {
     @DisplayName("Will test parent which is a private method...")
     @Test
     void testApplyParent() throws BadInputException {
-        final ProductCategoryPojo parentPojo = new ProductCategoryPojo();
-//        parentPojo.setCode(ANY);
         final ProductCategory parent = new ProductCategory();
         parent.setName(ANY);
         productCategory.setParent(parent);
         productCategory.setName(ANY);
-        productCategoryPojo.setParent(parentPojo);
+        productCategoryPojo.setParent(ProductCategoryPojo.builder().build());
         productCategory.setId(1L);
         when(categoriesRepository.save(any(ProductCategory.class))).thenReturn(parent);
         ProductCategory actual = sut.applyChangesToExistingEntity(productCategoryPojo, productCategory);
@@ -94,14 +93,12 @@ public class ProductCategoriesConverterJpaServiceImplTest {
 
     @Test
     void testApplyParent2() throws BadInputException {
-        final ProductCategoryPojo parentPojo = new ProductCategoryPojo();
-        parentPojo.setCode(ANY);
         final ProductCategory parent = new ProductCategory();
         parent.setName(ANY);
         parent.setCode("");
         productCategory.setParent(parent);
         productCategory.setName(ANY);
-        productCategoryPojo.setParent(parentPojo);
+        productCategoryPojo.setParent(ProductCategoryPojo.builder().code(ANY).build());
         productCategory.setId(1L);
         when(categoriesRepository.save(any(ProductCategory.class))).thenReturn(parent);
         ProductCategory actual = sut.applyChangesToExistingEntity(productCategoryPojo, productCategory);

--- a/src/test/java/org/trebol/jpa/services/conversion/ProductListConverterJpaServiceImplTest.java
+++ b/src/test/java/org/trebol/jpa/services/conversion/ProductListConverterJpaServiceImplTest.java
@@ -37,10 +37,11 @@ class ProductListConverterJpaServiceImplTest {
         productList.setName(ANY);
         productList.setName(ANY);
 
-        productListPojo = new ProductListPojo();
-        productListPojo.setId(1L);
-        productListPojo.setName(ANY + " ");
-        productListPojo.setCode(ANY + " ");
+        productListPojo = ProductListPojo.builder()
+          .id(1L)
+          .name(ANY + " ")
+          .code(ANY + " ")
+          .build();
     }
 
     @AfterEach

--- a/src/test/java/org/trebol/jpa/services/conversion/ProductListItemsConverterJpaServiceImplTest.java
+++ b/src/test/java/org/trebol/jpa/services/conversion/ProductListItemsConverterJpaServiceImplTest.java
@@ -52,10 +52,9 @@ class ProductListItemsConverterJpaServiceImplTest {
         productPojo.setId(1L);
         final ProductImage productImage = new ProductImage();
         productImage.setImage(new Image());
-        final ImagePojo imagePojo = new ImagePojo(ANY);
         when(conversionService.convert(any(Product.class), eq(ProductPojo.class))).thenReturn(productPojo);
         when(iProductImagesJpaRepository.deepFindProductImagesByProductId(anyLong())).thenReturn(List.of(productImage));
-        when(conversionService.convert(any(Image.class), eq(ImagePojo.class))).thenReturn(imagePojo);
+        when(conversionService.convert(any(Image.class), eq(ImagePojo.class))).thenReturn(ImagePojo.builder().filename(ANY).build());
 
         ProductPojo actual = sut.convertToPojo(productListItem);
 

--- a/src/test/java/org/trebol/jpa/services/conversion/ProductListItemsConverterJpaServiceImplTest.java
+++ b/src/test/java/org/trebol/jpa/services/conversion/ProductListItemsConverterJpaServiceImplTest.java
@@ -40,7 +40,7 @@ class ProductListItemsConverterJpaServiceImplTest {
     @Test
     void testApplyChangesToExistingEntity() {
         UnsupportedOperationException unsupportedOperationException = assertThrows(UnsupportedOperationException.class,
-                () -> sut.convertToNewEntity(new ProductPojo()));
+                () -> sut.convertToNewEntity(ProductPojo.builder().build()));
         assertEquals("Not implemented", unsupportedOperationException.getMessage());
     }
     @Test
@@ -48,11 +48,9 @@ class ProductListItemsConverterJpaServiceImplTest {
         final ProductListItem productListItem = new ProductListItem();
         final Product product = new Product();
         productListItem.setProduct(product);
-        final ProductPojo productPojo = new ProductPojo();
-        productPojo.setId(1L);
         final ProductImage productImage = new ProductImage();
         productImage.setImage(new Image());
-        when(conversionService.convert(any(Product.class), eq(ProductPojo.class))).thenReturn(productPojo);
+        when(conversionService.convert(any(Product.class), eq(ProductPojo.class))).thenReturn(ProductPojo.builder().id(1L).build());
         when(iProductImagesJpaRepository.deepFindProductImagesByProductId(anyLong())).thenReturn(List.of(productImage));
         when(conversionService.convert(any(Image.class), eq(ImagePojo.class))).thenReturn(ImagePojo.builder().filename(ANY).build());
 
@@ -64,7 +62,7 @@ class ProductListItemsConverterJpaServiceImplTest {
     @Test
     void testConvertToNewEntity() {
         UnsupportedOperationException unsupportedOperationException = assertThrows(UnsupportedOperationException.class,
-                () -> sut.applyChangesToExistingEntity(new ProductPojo(), new ProductListItem()));
+                () -> sut.applyChangesToExistingEntity(ProductPojo.builder().build(), new ProductListItem()));
         assertEquals("Not implemented", unsupportedOperationException.getMessage());
     }
 }

--- a/src/test/java/org/trebol/jpa/services/conversion/ProductsConverterJpaServiceImplTest.java
+++ b/src/test/java/org/trebol/jpa/services/conversion/ProductsConverterJpaServiceImplTest.java
@@ -79,11 +79,10 @@ public class ProductsConverterJpaServiceImplTest {
     void testConvertToPojo() {
         when(conversionService.convert(any(Product.class), eq(ProductPojo.class))).thenReturn(productPojo);
         final ProductImage productImage = new ProductImage();
-        final ImagePojo imagePojo = new ImagePojo();
         final Image image = new Image();
         productImage.setImage(image);
         when(productImagesRepository.deepFindProductImagesByProductId(anyLong())).thenReturn(List.of(productImage));
-        when(conversionService.convert(any(Image.class), eq(ImagePojo.class))).thenReturn(imagePojo);
+        when(conversionService.convert(any(Image.class), eq(ImagePojo.class))).thenReturn(ImagePojo.builder().build());
         final ProductCategory productCategory = new ProductCategory();
         product.setProductCategory(productCategory);
         when(conversionService.convert(any(ProductCategory.class), eq(ProductCategoryPojo.class))).thenReturn(new ProductCategoryPojo());

--- a/src/test/java/org/trebol/jpa/services/conversion/ProductsConverterJpaServiceImplTest.java
+++ b/src/test/java/org/trebol/jpa/services/conversion/ProductsConverterJpaServiceImplTest.java
@@ -49,9 +49,10 @@ public class ProductsConverterJpaServiceImplTest {
         product = new Product();
         product.setName(ANY);
         product.setId(1L);
-        productPojo = new ProductPojo();
-        productPojo.setId(1L);
-        productPojo.setName(ANY);
+        productPojo = ProductPojo.builder()
+          .id(1L)
+          .name(ANY)
+          .build();
     }
 
     @AfterEach

--- a/src/test/java/org/trebol/jpa/services/conversion/ProductsConverterJpaServiceImplTest.java
+++ b/src/test/java/org/trebol/jpa/services/conversion/ProductsConverterJpaServiceImplTest.java
@@ -85,7 +85,7 @@ public class ProductsConverterJpaServiceImplTest {
         when(conversionService.convert(any(Image.class), eq(ImagePojo.class))).thenReturn(ImagePojo.builder().build());
         final ProductCategory productCategory = new ProductCategory();
         product.setProductCategory(productCategory);
-        when(conversionService.convert(any(ProductCategory.class), eq(ProductCategoryPojo.class))).thenReturn(new ProductCategoryPojo());
+        when(conversionService.convert(any(ProductCategory.class), eq(ProductCategoryPojo.class))).thenReturn(ProductCategoryPojo.builder().build());
 
         ProductPojo actual = sut.convertToPojo(product);
 

--- a/src/test/java/org/trebol/jpa/services/conversion/SalesConverterJpaServiceImplTest.java
+++ b/src/test/java/org/trebol/jpa/services/conversion/SalesConverterJpaServiceImplTest.java
@@ -29,13 +29,7 @@ import org.trebol.jpa.repositories.ISellStatusesJpaRepository;
 import org.trebol.jpa.repositories.IShippersJpaRepository;
 import org.trebol.jpa.services.GenericCrudJpaService;
 import org.trebol.jpa.services.ITwoWayConverterJpaService;
-import org.trebol.pojo.AddressPojo;
-import org.trebol.pojo.BillingCompanyPojo;
-import org.trebol.pojo.CustomerPojo;
-import org.trebol.pojo.ProductPojo;
-import org.trebol.pojo.SalespersonPojo;
-import org.trebol.pojo.SellDetailPojo;
-import org.trebol.pojo.SellPojo;
+import org.trebol.pojo.*;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
@@ -145,7 +139,7 @@ class SalesConverterJpaServiceImplTest {
         when(conversion.convert(any(BillingCompany.class), eq(BillingCompanyPojo.class))).thenReturn(BillingCompanyPojo.builder().build());
         when(conversion.convert(any(Address.class), eq(AddressPojo.class))).thenReturn(AddressPojo.builder().build());
 
-        when(customersConverter.convertToPojo(any(Customer.class))).thenReturn(new CustomerPojo());
+        when(customersConverter.convertToPojo(any(Customer.class))).thenReturn(CustomerPojo.builder().build());
         when(salespeopleConverter.convertToPojo(any(Salesperson.class))).thenReturn(new SalespersonPojo());
 
         SellPojo actual = sut.convertToPojo(sell);
@@ -165,7 +159,7 @@ class SalesConverterJpaServiceImplTest {
         sell.setBillingType(new BillingType(ID_1L, "Enterprise Invoice"));
         sell.setCustomer(new Customer(ANY));
         when(conversion.convert(any(Sell. class), eq(SellPojo.class))).thenReturn(sellPojo);
-        when(customersConverter.convertToPojo(any(Customer.class))).thenReturn(new CustomerPojo());
+        when(customersConverter.convertToPojo(any(Customer.class))).thenReturn(CustomerPojo.builder().build());
 
         SellPojo actual = sut.convertToPojo(sell);
 
@@ -180,7 +174,7 @@ class SalesConverterJpaServiceImplTest {
         sell.setBillingType(new BillingType(ID_1L, "Enterprise Invoicesss"));
         sell.setCustomer(new Customer(ANY));
         when(conversion.convert(any(Sell. class), eq(SellPojo.class))).thenReturn(sellPojo);
-        when(customersConverter.convertToPojo(any(Customer.class))).thenReturn(new CustomerPojo());
+        when(customersConverter.convertToPojo(any(Customer.class))).thenReturn(CustomerPojo.builder().build());
 
         SellPojo actual = sut.convertToPojo(sell);
 
@@ -359,7 +353,7 @@ class SalesConverterJpaServiceImplTest {
         sellPojo.setPaymentType(ANY);
         sellPojo.setBillingType("Enterprise Invoice");
         sellPojo.setBillingCompany(BillingCompanyPojo.builder().idNumber(ANY).build());
-        sellPojo.setCustomer(new CustomerPojo(ANY));
+        sellPojo.setCustomer(CustomerPojo.builder().person(PersonPojo.builder().idNumber(ANY).build()).build());
         final SellDetailPojo sellDetailPojo = new SellDetailPojo();
         sellDetailPojo.setProduct(new ProductPojo(null));
         sellPojo.setDetails(List.of(sellDetailPojo));
@@ -408,7 +402,7 @@ class SalesConverterJpaServiceImplTest {
         sellPojo.setPaymentType(ANY);
         sellPojo.setBillingType("Enterprise Invoice");
         sellPojo.setBillingCompany(BillingCompanyPojo.builder().idNumber(ANY).build());
-        sellPojo.setCustomer(new CustomerPojo(ANY));
+        sellPojo.setCustomer(CustomerPojo.builder().person(PersonPojo.builder().idNumber(ANY).build()).build());
         final SellDetailPojo sellDetailPojo = new SellDetailPojo();
         sellDetailPojo.setProduct(new ProductPojo(ANY));
         sellPojo.setDetails(List.of(sellDetailPojo));
@@ -458,7 +452,7 @@ class SalesConverterJpaServiceImplTest {
         sellPojo.setPaymentType(ANY);
         sellPojo.setBillingType("Enterprise Invoice");
         sellPojo.setBillingCompany(BillingCompanyPojo.builder().idNumber(ANY).build());
-        sellPojo.setCustomer(new CustomerPojo(ANY));
+        sellPojo.setCustomer(CustomerPojo.builder().person(PersonPojo.builder().idNumber(ANY).build()).build());
         final SellDetailPojo sellDetailPojo = new SellDetailPojo();
         sellDetailPojo.setProduct(new ProductPojo(ANY));
         sellDetailPojo.setUnits(1);
@@ -511,7 +505,7 @@ class SalesConverterJpaServiceImplTest {
         sellPojo.setPaymentType(ANY);
         sellPojo.setBillingType("Enterprise Invoice");
         sellPojo.setBillingCompany(BillingCompanyPojo.builder().idNumber(ANY).build());
-        sellPojo.setCustomer(new CustomerPojo(ANY));
+        sellPojo.setCustomer(CustomerPojo.builder().person(PersonPojo.builder().idNumber(ANY).build()).build());
         final SellDetailPojo sellDetailPojo = new SellDetailPojo();
         sellDetailPojo.setProduct(new ProductPojo(ANY));
         sellDetailPojo.setUnits(1);
@@ -566,7 +560,7 @@ class SalesConverterJpaServiceImplTest {
         sellPojo.setPaymentType(ANY);
         sellPojo.setBillingType("Enterprise Invoice");
         sellPojo.setBillingCompany(BillingCompanyPojo.builder().idNumber(ANY).build());
-        sellPojo.setCustomer(new CustomerPojo(ANY));
+        sellPojo.setCustomer(CustomerPojo.builder().person(PersonPojo.builder().idNumber(ANY).build()).build()); // TODO refactor this inline CustomerPojo, there's 6 of these
         final SellDetailPojo sellDetailPojo = new SellDetailPojo();
         sellDetailPojo.setProduct(new ProductPojo(ANY));
         sellDetailPojo.setUnits(1);

--- a/src/test/java/org/trebol/jpa/services/conversion/SalesConverterJpaServiceImplTest.java
+++ b/src/test/java/org/trebol/jpa/services/conversion/SalesConverterJpaServiceImplTest.java
@@ -140,7 +140,7 @@ class SalesConverterJpaServiceImplTest {
         when(conversion.convert(any(Address.class), eq(AddressPojo.class))).thenReturn(AddressPojo.builder().build());
 
         when(customersConverter.convertToPojo(any(Customer.class))).thenReturn(CustomerPojo.builder().build());
-        when(salespeopleConverter.convertToPojo(any(Salesperson.class))).thenReturn(new SalespersonPojo());
+        when(salespeopleConverter.convertToPojo(any(Salesperson.class))).thenReturn(SalespersonPojo.builder().build());
 
         SellPojo actual = sut.convertToPojo(sell);
 

--- a/src/test/java/org/trebol/jpa/services/conversion/SalesConverterJpaServiceImplTest.java
+++ b/src/test/java/org/trebol/jpa/services/conversion/SalesConverterJpaServiceImplTest.java
@@ -142,8 +142,8 @@ class SalesConverterJpaServiceImplTest {
         sell.setCustomer(new Customer(ANY));
         sell.setSalesperson(new Salesperson(ANY));
         when(conversion.convert(any(Sell. class), eq(SellPojo.class))).thenReturn(sellPojo);
-        when(conversion.convert(any(BillingCompany.class), eq(BillingCompanyPojo.class))).thenReturn(BillingCompanyPojo.builder().build());
-        when(conversion.convert(any(Address.class), eq(AddressPojo.class))).thenReturn(AddressPojo.builder().build());
+        when(conversion.convert(any(BillingCompany.class), eq(BillingCompanyPojo.class))).thenReturn(new BillingCompanyPojo());
+        when(conversion.convert(any(Address.class), eq(AddressPojo.class))).thenReturn(new AddressPojo());
 
         when(customersConverter.convertToPojo(any(Customer.class))).thenReturn(new CustomerPojo());
         when(salespeopleConverter.convertToPojo(any(Salesperson.class))).thenReturn(new SalespersonPojo());
@@ -268,7 +268,7 @@ class SalesConverterJpaServiceImplTest {
         sellPojo.setDate(Instant.now());
         sellPojo.setPaymentType(ANY);
         sellPojo.setBillingType("Enterprise Invoice");
-        sellPojo.setBillingCompany(BillingCompanyPojo.builder().build());
+        sellPojo.setBillingCompany(new BillingCompanyPojo());
 
         when(statusesRepository.findByName(anyString())).thenReturn(Optional.of(new SellStatus(ID_1L, 1, ANY)));
         when(paymentTypesRepository.findByName(anyString())).thenReturn(Optional.of(new PaymentType(ID_1L, ANY)));
@@ -571,7 +571,7 @@ class SalesConverterJpaServiceImplTest {
         sellDetailPojo.setProduct(new ProductPojo(ANY));
         sellDetailPojo.setUnits(1);
         sellPojo.setDetails(List.of(sellDetailPojo));
-        sellPojo.setBillingAddress(AddressPojo.builder().build());
+        sellPojo.setBillingAddress(new AddressPojo());
 
         when(statusesRepository.findByName(anyString())).thenReturn(Optional.of(new SellStatus(ID_1L, 1, ANY)));
         when(paymentTypesRepository.findByName(anyString())).thenReturn(Optional.of(new PaymentType(ID_1L, ANY)));

--- a/src/test/java/org/trebol/jpa/services/conversion/SalesConverterJpaServiceImplTest.java
+++ b/src/test/java/org/trebol/jpa/services/conversion/SalesConverterJpaServiceImplTest.java
@@ -113,7 +113,7 @@ class SalesConverterJpaServiceImplTest {
                  productsRepository,
                  validator,
                  validationProperties);
-        sellPojo = new SellPojo();
+        sellPojo = SellPojo.builder().build();
         sell = new Sell();
     }
 

--- a/src/test/java/org/trebol/jpa/services/conversion/SalesConverterJpaServiceImplTest.java
+++ b/src/test/java/org/trebol/jpa/services/conversion/SalesConverterJpaServiceImplTest.java
@@ -142,8 +142,8 @@ class SalesConverterJpaServiceImplTest {
         sell.setCustomer(new Customer(ANY));
         sell.setSalesperson(new Salesperson(ANY));
         when(conversion.convert(any(Sell. class), eq(SellPojo.class))).thenReturn(sellPojo);
-        when(conversion.convert(any(BillingCompany.class), eq(BillingCompanyPojo.class))).thenReturn(new BillingCompanyPojo());
-        when(conversion.convert(any(Address.class), eq(AddressPojo.class))).thenReturn(new AddressPojo());
+        when(conversion.convert(any(BillingCompany.class), eq(BillingCompanyPojo.class))).thenReturn(BillingCompanyPojo.builder().build());
+        when(conversion.convert(any(Address.class), eq(AddressPojo.class))).thenReturn(AddressPojo.builder().build());
 
         when(customersConverter.convertToPojo(any(Customer.class))).thenReturn(new CustomerPojo());
         when(salespeopleConverter.convertToPojo(any(Salesperson.class))).thenReturn(new SalespersonPojo());
@@ -268,7 +268,7 @@ class SalesConverterJpaServiceImplTest {
         sellPojo.setDate(Instant.now());
         sellPojo.setPaymentType(ANY);
         sellPojo.setBillingType("Enterprise Invoice");
-        sellPojo.setBillingCompany(new BillingCompanyPojo());
+        sellPojo.setBillingCompany(BillingCompanyPojo.builder().build());
 
         when(statusesRepository.findByName(anyString())).thenReturn(Optional.of(new SellStatus(ID_1L, 1, ANY)));
         when(paymentTypesRepository.findByName(anyString())).thenReturn(Optional.of(new PaymentType(ID_1L, ANY)));
@@ -571,7 +571,7 @@ class SalesConverterJpaServiceImplTest {
         sellDetailPojo.setProduct(new ProductPojo(ANY));
         sellDetailPojo.setUnits(1);
         sellPojo.setDetails(List.of(sellDetailPojo));
-        sellPojo.setBillingAddress(new AddressPojo());
+        sellPojo.setBillingAddress(AddressPojo.builder().build());
 
         when(statusesRepository.findByName(anyString())).thenReturn(Optional.of(new SellStatus(ID_1L, 1, ANY)));
         when(paymentTypesRepository.findByName(anyString())).thenReturn(Optional.of(new PaymentType(ID_1L, ANY)));

--- a/src/test/java/org/trebol/jpa/services/conversion/SalesConverterJpaServiceImplTest.java
+++ b/src/test/java/org/trebol/jpa/services/conversion/SalesConverterJpaServiceImplTest.java
@@ -404,7 +404,7 @@ class SalesConverterJpaServiceImplTest {
         sellPojo.setBillingCompany(BillingCompanyPojo.builder().idNumber(ANY).build());
         sellPojo.setCustomer(CustomerPojo.builder().person(PersonPojo.builder().idNumber(ANY).build()).build());
         sellPojo.setDetails(List.of(SellDetailPojo.builder()
-                                      .product(ProductPojo.builder().build())
+                                      .product(ProductPojo.builder().barcode(ANY).build())
                                       .build()));
 
         when(statusesRepository.findByName(anyString())).thenReturn(Optional.of(new SellStatus(ID_1L, 1, ANY)));
@@ -454,7 +454,7 @@ class SalesConverterJpaServiceImplTest {
         sellPojo.setBillingCompany(BillingCompanyPojo.builder().idNumber(ANY).build());
         sellPojo.setCustomer(CustomerPojo.builder().person(PersonPojo.builder().idNumber(ANY).build()).build());
         sellPojo.setDetails(List.of(SellDetailPojo.builder()
-                                      .product(ProductPojo.builder().build())
+                                      .product(ProductPojo.builder().barcode(ANY).build())
                                       .units(1)
                                       .build()));
 
@@ -507,7 +507,7 @@ class SalesConverterJpaServiceImplTest {
         sellPojo.setBillingCompany(BillingCompanyPojo.builder().idNumber(ANY).build());
         sellPojo.setCustomer(CustomerPojo.builder().person(PersonPojo.builder().idNumber(ANY).build()).build());
         sellPojo.setDetails(List.of(SellDetailPojo.builder()
-                                      .product(ProductPojo.builder().build())
+                                      .product(ProductPojo.builder().barcode(ANY).build())
                                       .units(1)
                                       .build()));
 
@@ -562,7 +562,7 @@ class SalesConverterJpaServiceImplTest {
         sellPojo.setBillingCompany(BillingCompanyPojo.builder().idNumber(ANY).build());
         sellPojo.setCustomer(CustomerPojo.builder().person(PersonPojo.builder().idNumber(ANY).build()).build()); // TODO refactor this inline CustomerPojo, there's 6 of these
         sellPojo.setDetails(List.of(SellDetailPojo.builder()
-                                      .product(ProductPojo.builder().build())
+                                      .product(ProductPojo.builder().barcode(ANY).build())
                                       .units(1)
                                       .build()));
         sellPojo.setBillingAddress(AddressPojo.builder().build());

--- a/src/test/java/org/trebol/jpa/services/conversion/SalesConverterJpaServiceImplTest.java
+++ b/src/test/java/org/trebol/jpa/services/conversion/SalesConverterJpaServiceImplTest.java
@@ -354,9 +354,9 @@ class SalesConverterJpaServiceImplTest {
         sellPojo.setBillingType("Enterprise Invoice");
         sellPojo.setBillingCompany(BillingCompanyPojo.builder().idNumber(ANY).build());
         sellPojo.setCustomer(CustomerPojo.builder().person(PersonPojo.builder().idNumber(ANY).build()).build());
-        final SellDetailPojo sellDetailPojo = new SellDetailPojo();
-        sellDetailPojo.setProduct(ProductPojo.builder().build());
-        sellPojo.setDetails(List.of(sellDetailPojo));
+        sellPojo.setDetails(List.of(SellDetailPojo.builder()
+                                      .product(ProductPojo.builder().build())
+                                      .build()));
 
         when(statusesRepository.findByName(anyString())).thenReturn(Optional.of(new SellStatus(ID_1L, 1, ANY)));
         when(paymentTypesRepository.findByName(anyString())).thenReturn(Optional.of(new PaymentType(ID_1L, ANY)));
@@ -403,9 +403,9 @@ class SalesConverterJpaServiceImplTest {
         sellPojo.setBillingType("Enterprise Invoice");
         sellPojo.setBillingCompany(BillingCompanyPojo.builder().idNumber(ANY).build());
         sellPojo.setCustomer(CustomerPojo.builder().person(PersonPojo.builder().idNumber(ANY).build()).build());
-        final SellDetailPojo sellDetailPojo = new SellDetailPojo();
-        sellDetailPojo.setProduct(ProductPojo.builder().build());
-        sellPojo.setDetails(List.of(sellDetailPojo));
+        sellPojo.setDetails(List.of(SellDetailPojo.builder()
+                                      .product(ProductPojo.builder().build())
+                                      .build()));
 
         when(statusesRepository.findByName(anyString())).thenReturn(Optional.of(new SellStatus(ID_1L, 1, ANY)));
         when(paymentTypesRepository.findByName(anyString())).thenReturn(Optional.of(new PaymentType(ID_1L, ANY)));
@@ -453,10 +453,10 @@ class SalesConverterJpaServiceImplTest {
         sellPojo.setBillingType("Enterprise Invoice");
         sellPojo.setBillingCompany(BillingCompanyPojo.builder().idNumber(ANY).build());
         sellPojo.setCustomer(CustomerPojo.builder().person(PersonPojo.builder().idNumber(ANY).build()).build());
-        final SellDetailPojo sellDetailPojo = new SellDetailPojo();
-        sellDetailPojo.setProduct(ProductPojo.builder().build());
-        sellDetailPojo.setUnits(1);
-        sellPojo.setDetails(List.of(sellDetailPojo));
+        sellPojo.setDetails(List.of(SellDetailPojo.builder()
+                                      .product(ProductPojo.builder().build())
+                                      .units(1)
+                                      .build()));
 
         when(statusesRepository.findByName(anyString())).thenReturn(Optional.of(new SellStatus(ID_1L, 1, ANY)));
         when(paymentTypesRepository.findByName(anyString())).thenReturn(Optional.of(new PaymentType(ID_1L, ANY)));
@@ -506,10 +506,10 @@ class SalesConverterJpaServiceImplTest {
         sellPojo.setBillingType("Enterprise Invoice");
         sellPojo.setBillingCompany(BillingCompanyPojo.builder().idNumber(ANY).build());
         sellPojo.setCustomer(CustomerPojo.builder().person(PersonPojo.builder().idNumber(ANY).build()).build());
-        final SellDetailPojo sellDetailPojo = new SellDetailPojo();
-        sellDetailPojo.setProduct(ProductPojo.builder().build());
-        sellDetailPojo.setUnits(1);
-        sellPojo.setDetails(List.of(sellDetailPojo));
+        sellPojo.setDetails(List.of(SellDetailPojo.builder()
+                                      .product(ProductPojo.builder().build())
+                                      .units(1)
+                                      .build()));
 
         when(statusesRepository.findByName(anyString())).thenReturn(Optional.of(new SellStatus(ID_1L, 1, ANY)));
         when(paymentTypesRepository.findByName(anyString())).thenReturn(Optional.of(new PaymentType(ID_1L, ANY)));
@@ -561,10 +561,10 @@ class SalesConverterJpaServiceImplTest {
         sellPojo.setBillingType("Enterprise Invoice");
         sellPojo.setBillingCompany(BillingCompanyPojo.builder().idNumber(ANY).build());
         sellPojo.setCustomer(CustomerPojo.builder().person(PersonPojo.builder().idNumber(ANY).build()).build()); // TODO refactor this inline CustomerPojo, there's 6 of these
-        final SellDetailPojo sellDetailPojo = new SellDetailPojo();
-        sellDetailPojo.setProduct(ProductPojo.builder().build());
-        sellDetailPojo.setUnits(1);
-        sellPojo.setDetails(List.of(sellDetailPojo));
+        sellPojo.setDetails(List.of(SellDetailPojo.builder()
+                                      .product(ProductPojo.builder().build())
+                                      .units(1)
+                                      .build()));
         sellPojo.setBillingAddress(AddressPojo.builder().build());
 
         when(statusesRepository.findByName(anyString())).thenReturn(Optional.of(new SellStatus(ID_1L, 1, ANY)));

--- a/src/test/java/org/trebol/jpa/services/conversion/SalesConverterJpaServiceImplTest.java
+++ b/src/test/java/org/trebol/jpa/services/conversion/SalesConverterJpaServiceImplTest.java
@@ -143,7 +143,7 @@ class SalesConverterJpaServiceImplTest {
         sell.setSalesperson(new Salesperson(ANY));
         when(conversion.convert(any(Sell. class), eq(SellPojo.class))).thenReturn(sellPojo);
         when(conversion.convert(any(BillingCompany.class), eq(BillingCompanyPojo.class))).thenReturn(new BillingCompanyPojo());
-        when(conversion.convert(any(Address.class), eq(AddressPojo.class))).thenReturn(new AddressPojo());
+        when(conversion.convert(any(Address.class), eq(AddressPojo.class))).thenReturn(AddressPojo.builder().build());
 
         when(customersConverter.convertToPojo(any(Customer.class))).thenReturn(new CustomerPojo());
         when(salespeopleConverter.convertToPojo(any(Salesperson.class))).thenReturn(new SalespersonPojo());
@@ -571,7 +571,7 @@ class SalesConverterJpaServiceImplTest {
         sellDetailPojo.setProduct(new ProductPojo(ANY));
         sellDetailPojo.setUnits(1);
         sellPojo.setDetails(List.of(sellDetailPojo));
-        sellPojo.setBillingAddress(new AddressPojo());
+        sellPojo.setBillingAddress(AddressPojo.builder().build());
 
         when(statusesRepository.findByName(anyString())).thenReturn(Optional.of(new SellStatus(ID_1L, 1, ANY)));
         when(paymentTypesRepository.findByName(anyString())).thenReturn(Optional.of(new PaymentType(ID_1L, ANY)));

--- a/src/test/java/org/trebol/jpa/services/conversion/SalesConverterJpaServiceImplTest.java
+++ b/src/test/java/org/trebol/jpa/services/conversion/SalesConverterJpaServiceImplTest.java
@@ -142,7 +142,7 @@ class SalesConverterJpaServiceImplTest {
         sell.setCustomer(new Customer(ANY));
         sell.setSalesperson(new Salesperson(ANY));
         when(conversion.convert(any(Sell. class), eq(SellPojo.class))).thenReturn(sellPojo);
-        when(conversion.convert(any(BillingCompany.class), eq(BillingCompanyPojo.class))).thenReturn(new BillingCompanyPojo());
+        when(conversion.convert(any(BillingCompany.class), eq(BillingCompanyPojo.class))).thenReturn(BillingCompanyPojo.builder().build());
         when(conversion.convert(any(Address.class), eq(AddressPojo.class))).thenReturn(AddressPojo.builder().build());
 
         when(customersConverter.convertToPojo(any(Customer.class))).thenReturn(new CustomerPojo());
@@ -268,7 +268,7 @@ class SalesConverterJpaServiceImplTest {
         sellPojo.setDate(Instant.now());
         sellPojo.setPaymentType(ANY);
         sellPojo.setBillingType("Enterprise Invoice");
-        sellPojo.setBillingCompany(new BillingCompanyPojo());
+        sellPojo.setBillingCompany(BillingCompanyPojo.builder().build());
 
         when(statusesRepository.findByName(anyString())).thenReturn(Optional.of(new SellStatus(ID_1L, 1, ANY)));
         when(paymentTypesRepository.findByName(anyString())).thenReturn(Optional.of(new PaymentType(ID_1L, ANY)));
@@ -286,7 +286,7 @@ class SalesConverterJpaServiceImplTest {
         sellPojo.setDate(Instant.now());
         sellPojo.setPaymentType(ANY);
         sellPojo.setBillingType("Enterprise Invoice");
-        sellPojo.setBillingCompany(new BillingCompanyPojo(ANY));
+        sellPojo.setBillingCompany(BillingCompanyPojo.builder().idNumber(ANY).build());
 
         when(statusesRepository.findByName(anyString())).thenReturn(Optional.of(new SellStatus(ID_1L, 1, ANY)));
         when(paymentTypesRepository.findByName(anyString())).thenReturn(Optional.of(new PaymentType(ID_1L, ANY)));
@@ -321,7 +321,7 @@ class SalesConverterJpaServiceImplTest {
         sellPojo.setDate(Instant.now());
         sellPojo.setPaymentType(ANY);
         sellPojo.setBillingType("Enterprise Invoice");
-        sellPojo.setBillingCompany(new BillingCompanyPojo(ANY));
+        sellPojo.setBillingCompany(BillingCompanyPojo.builder().idNumber(ANY).build());
 
         when(statusesRepository.findByName(anyString())).thenReturn(Optional.of(new SellStatus(ID_1L, 1, ANY)));
         when(paymentTypesRepository.findByName(anyString())).thenReturn(Optional.of(new PaymentType(ID_1L, ANY)));
@@ -358,7 +358,7 @@ class SalesConverterJpaServiceImplTest {
         sellPojo.setDate(Instant.now());
         sellPojo.setPaymentType(ANY);
         sellPojo.setBillingType("Enterprise Invoice");
-        sellPojo.setBillingCompany(new BillingCompanyPojo(ANY));
+        sellPojo.setBillingCompany(BillingCompanyPojo.builder().idNumber(ANY).build());
         sellPojo.setCustomer(new CustomerPojo(ANY));
         final SellDetailPojo sellDetailPojo = new SellDetailPojo();
         sellDetailPojo.setProduct(new ProductPojo(null));
@@ -407,7 +407,7 @@ class SalesConverterJpaServiceImplTest {
         sellPojo.setDate(Instant.now());
         sellPojo.setPaymentType(ANY);
         sellPojo.setBillingType("Enterprise Invoice");
-        sellPojo.setBillingCompany(new BillingCompanyPojo(ANY));
+        sellPojo.setBillingCompany(BillingCompanyPojo.builder().idNumber(ANY).build());
         sellPojo.setCustomer(new CustomerPojo(ANY));
         final SellDetailPojo sellDetailPojo = new SellDetailPojo();
         sellDetailPojo.setProduct(new ProductPojo(ANY));
@@ -457,7 +457,7 @@ class SalesConverterJpaServiceImplTest {
         sellPojo.setDate(Instant.now());
         sellPojo.setPaymentType(ANY);
         sellPojo.setBillingType("Enterprise Invoice");
-        sellPojo.setBillingCompany(new BillingCompanyPojo(ANY));
+        sellPojo.setBillingCompany(BillingCompanyPojo.builder().idNumber(ANY).build());
         sellPojo.setCustomer(new CustomerPojo(ANY));
         final SellDetailPojo sellDetailPojo = new SellDetailPojo();
         sellDetailPojo.setProduct(new ProductPojo(ANY));
@@ -510,7 +510,7 @@ class SalesConverterJpaServiceImplTest {
         sellPojo.setDate(Instant.now());
         sellPojo.setPaymentType(ANY);
         sellPojo.setBillingType("Enterprise Invoice");
-        sellPojo.setBillingCompany(new BillingCompanyPojo(ANY));
+        sellPojo.setBillingCompany(BillingCompanyPojo.builder().idNumber(ANY).build());
         sellPojo.setCustomer(new CustomerPojo(ANY));
         final SellDetailPojo sellDetailPojo = new SellDetailPojo();
         sellDetailPojo.setProduct(new ProductPojo(ANY));
@@ -565,7 +565,7 @@ class SalesConverterJpaServiceImplTest {
         sellPojo.setDate(Instant.now());
         sellPojo.setPaymentType(ANY);
         sellPojo.setBillingType("Enterprise Invoice");
-        sellPojo.setBillingCompany(new BillingCompanyPojo(ANY));
+        sellPojo.setBillingCompany(BillingCompanyPojo.builder().idNumber(ANY).build());
         sellPojo.setCustomer(new CustomerPojo(ANY));
         final SellDetailPojo sellDetailPojo = new SellDetailPojo();
         sellDetailPojo.setProduct(new ProductPojo(ANY));

--- a/src/test/java/org/trebol/jpa/services/conversion/SalesConverterJpaServiceImplTest.java
+++ b/src/test/java/org/trebol/jpa/services/conversion/SalesConverterJpaServiceImplTest.java
@@ -355,7 +355,7 @@ class SalesConverterJpaServiceImplTest {
         sellPojo.setBillingCompany(BillingCompanyPojo.builder().idNumber(ANY).build());
         sellPojo.setCustomer(CustomerPojo.builder().person(PersonPojo.builder().idNumber(ANY).build()).build());
         final SellDetailPojo sellDetailPojo = new SellDetailPojo();
-        sellDetailPojo.setProduct(new ProductPojo(null));
+        sellDetailPojo.setProduct(ProductPojo.builder().build());
         sellPojo.setDetails(List.of(sellDetailPojo));
 
         when(statusesRepository.findByName(anyString())).thenReturn(Optional.of(new SellStatus(ID_1L, 1, ANY)));
@@ -404,7 +404,7 @@ class SalesConverterJpaServiceImplTest {
         sellPojo.setBillingCompany(BillingCompanyPojo.builder().idNumber(ANY).build());
         sellPojo.setCustomer(CustomerPojo.builder().person(PersonPojo.builder().idNumber(ANY).build()).build());
         final SellDetailPojo sellDetailPojo = new SellDetailPojo();
-        sellDetailPojo.setProduct(new ProductPojo(ANY));
+        sellDetailPojo.setProduct(ProductPojo.builder().build());
         sellPojo.setDetails(List.of(sellDetailPojo));
 
         when(statusesRepository.findByName(anyString())).thenReturn(Optional.of(new SellStatus(ID_1L, 1, ANY)));
@@ -454,7 +454,7 @@ class SalesConverterJpaServiceImplTest {
         sellPojo.setBillingCompany(BillingCompanyPojo.builder().idNumber(ANY).build());
         sellPojo.setCustomer(CustomerPojo.builder().person(PersonPojo.builder().idNumber(ANY).build()).build());
         final SellDetailPojo sellDetailPojo = new SellDetailPojo();
-        sellDetailPojo.setProduct(new ProductPojo(ANY));
+        sellDetailPojo.setProduct(ProductPojo.builder().build());
         sellDetailPojo.setUnits(1);
         sellPojo.setDetails(List.of(sellDetailPojo));
 
@@ -507,7 +507,7 @@ class SalesConverterJpaServiceImplTest {
         sellPojo.setBillingCompany(BillingCompanyPojo.builder().idNumber(ANY).build());
         sellPojo.setCustomer(CustomerPojo.builder().person(PersonPojo.builder().idNumber(ANY).build()).build());
         final SellDetailPojo sellDetailPojo = new SellDetailPojo();
-        sellDetailPojo.setProduct(new ProductPojo(ANY));
+        sellDetailPojo.setProduct(ProductPojo.builder().build());
         sellDetailPojo.setUnits(1);
         sellPojo.setDetails(List.of(sellDetailPojo));
 
@@ -562,7 +562,7 @@ class SalesConverterJpaServiceImplTest {
         sellPojo.setBillingCompany(BillingCompanyPojo.builder().idNumber(ANY).build());
         sellPojo.setCustomer(CustomerPojo.builder().person(PersonPojo.builder().idNumber(ANY).build()).build()); // TODO refactor this inline CustomerPojo, there's 6 of these
         final SellDetailPojo sellDetailPojo = new SellDetailPojo();
-        sellDetailPojo.setProduct(new ProductPojo(ANY));
+        sellDetailPojo.setProduct(ProductPojo.builder().build());
         sellDetailPojo.setUnits(1);
         sellPojo.setDetails(List.of(sellDetailPojo));
         sellPojo.setBillingAddress(AddressPojo.builder().build());

--- a/src/test/java/org/trebol/jpa/services/conversion/SalespeopleConverterJpaServiceImplTest.java
+++ b/src/test/java/org/trebol/jpa/services/conversion/SalespeopleConverterJpaServiceImplTest.java
@@ -36,8 +36,7 @@ public class SalespeopleConverterJpaServiceImplTest {
 
     @BeforeEach
     void beforeEach() {
-        personPojo = new PersonPojo();
-        personPojo.setId(ID_1L);
+        personPojo = PersonPojo.builder().id(ID_1L).build();
         person = new Person();
         person.setId(ID_1L);
         salesperson = new Salesperson();

--- a/src/test/java/org/trebol/jpa/services/conversion/SalespeopleConverterJpaServiceImplTest.java
+++ b/src/test/java/org/trebol/jpa/services/conversion/SalespeopleConverterJpaServiceImplTest.java
@@ -43,8 +43,7 @@ public class SalespeopleConverterJpaServiceImplTest {
         salesperson.setId(ID_1L);
         salesperson.setPerson(person);
 
-        salespersonPojo = new SalespersonPojo();
-        salespersonPojo.setPerson(personPojo);
+        salespersonPojo = SalespersonPojo.builder().person(personPojo).build();
     }
 
 

--- a/src/test/java/org/trebol/jpa/services/conversion/SellStatusesConverterJpaServiceImplTest.java
+++ b/src/test/java/org/trebol/jpa/services/conversion/SellStatusesConverterJpaServiceImplTest.java
@@ -38,8 +38,7 @@ class SellStatusesConverterJpaServiceImplTest {
         sellStatus.setId(1L);
         sellStatus.setName(ANY);
 
-        sellStatusPojo = new SellStatusPojo();
-        sellStatusPojo.setName(ANY);
+        sellStatusPojo = SellStatusPojo.builder().name(ANY).build();
     }
 
     @AfterEach

--- a/src/test/java/org/trebol/jpa/services/conversion/ShippersConverterJpaServiceImplTest.java
+++ b/src/test/java/org/trebol/jpa/services/conversion/ShippersConverterJpaServiceImplTest.java
@@ -38,8 +38,7 @@ class ShippersConverterJpaServiceImplTest {
         shipper.setId(1L);
         shipper.setName(ANY);
 
-        shipperPojo = new ShipperPojo();
-        shipperPojo.setName(ANY);
+        shipperPojo = ShipperPojo.builder().name(ANY).build();
     }
 
     @AfterEach

--- a/src/test/java/org/trebol/jpa/services/conversion/UserRolesConverterJpaServiceImplTest.java
+++ b/src/test/java/org/trebol/jpa/services/conversion/UserRolesConverterJpaServiceImplTest.java
@@ -37,9 +37,10 @@ class UserRolesConverterJpaServiceImplTest {
         userRole.setName("ANY");
         userRole.setId(1L);
 
-        userRolePojo = new UserRolePojo();
-        userRolePojo.setId(1L);
-        userRolePojo.setName("ANY");
+        userRolePojo = UserRolePojo.builder()
+          .id(1L)
+          .name("ANY")
+          .build();
     }
 
     @AfterEach

--- a/src/test/java/org/trebol/jpa/services/conversion/UsersConverterJpaServiceImplTest.java
+++ b/src/test/java/org/trebol/jpa/services/conversion/UsersConverterJpaServiceImplTest.java
@@ -105,7 +105,7 @@ public class UsersConverterJpaServiceImplTest {
 
     @Test
     void testConvertToPojo() {
-        when(peopleService.convertToPojo(any(Person.class))).thenReturn(new PersonPojo());
+        when(peopleService.convertToPojo(any(Person.class))).thenReturn(PersonPojo.builder().build());
         UserPojo actual = sut.convertToPojo(user);
         assertNotNull(actual.getPerson());
     }

--- a/src/test/java/org/trebol/jpa/services/conversion/UsersConverterJpaServiceImplTest.java
+++ b/src/test/java/org/trebol/jpa/services/conversion/UsersConverterJpaServiceImplTest.java
@@ -79,8 +79,7 @@ public class UsersConverterJpaServiceImplTest {
         userPojo.setName(ANY);
         userPojo.setRole(ANY);
         userPojo.setPassword(ANY);
-        final PersonPojo personPojo = new PersonPojo();
-        personPojo.setIdNumber(ANY);
+        final PersonPojo personPojo = PersonPojo.builder().idNumber(ANY).build();
         userPojo.setPerson(personPojo);
 
 
@@ -130,8 +129,7 @@ public class UsersConverterJpaServiceImplTest {
         when(rolesRepository.findByName(anyString())).thenReturn(Optional.of(userRole));
 
         userPojo.setPassword(ANY);
-        final PersonPojo personPojo = new PersonPojo();
-        personPojo.setIdNumber(ANY);
+        final PersonPojo personPojo = PersonPojo.builder().idNumber(ANY).build();
         userPojo.setPerson(personPojo);
         userPojo.setRole(ANY);
 

--- a/src/test/java/org/trebol/jpa/services/conversion/UsersConverterJpaServiceImplTest.java
+++ b/src/test/java/org/trebol/jpa/services/conversion/UsersConverterJpaServiceImplTest.java
@@ -62,9 +62,10 @@ public class UsersConverterJpaServiceImplTest {
         user.setUserRole(userRole);
         Person person = new Person();
         user.setPerson(person);
-        userPojo = new UserPojo();
-        userPojo.setId(1L);
-        userPojo.setName(ANY);
+        userPojo = UserPojo.builder()
+          .id(1L)
+          .name(ANY)
+          .build();
     }
 
     @AfterEach

--- a/src/test/java/org/trebol/jpa/services/crud/BillingCompaniesJpaCrudServiceTest.java
+++ b/src/test/java/org/trebol/jpa/services/crud/BillingCompaniesJpaCrudServiceTest.java
@@ -42,7 +42,7 @@ class BillingCompaniesJpaCrudServiceTest {
     Long companyId = 1L;
     String companyIdNumber = "11111111";
     String companyName = "test company";
-    BillingCompanyPojo example = new BillingCompanyPojo(companyIdNumber);
+    BillingCompanyPojo example = BillingCompanyPojo.builder().idNumber(companyIdNumber).build();
     BillingCompany persistedEntity = new BillingCompany(companyId, companyIdNumber, companyName);
     when(billingCompaniesRepositoryMock.findByIdNumber(companyIdNumber)).thenReturn(Optional.of(persistedEntity));
 

--- a/src/test/java/org/trebol/jpa/services/crud/BillingTypesJpaCrudServiceTest.java
+++ b/src/test/java/org/trebol/jpa/services/crud/BillingTypesJpaCrudServiceTest.java
@@ -42,7 +42,7 @@ class BillingTypesJpaCrudServiceTest {
   void finds_by_name() throws BadInputException {
     Long billingTypeId = 1L;
     String billingTypeName = "test company";
-    BillingTypePojo example = new BillingTypePojo(billingTypeName);
+    BillingTypePojo example = BillingTypePojo.builder().name(billingTypeName).build();
     BillingType persistedEntity = new BillingType(billingTypeId, billingTypeName);
     when(billingTypesRepositoryMock.findByName(billingTypeName)).thenReturn(Optional.of(persistedEntity));
 

--- a/src/test/java/org/trebol/jpa/services/crud/ProductsJpaCrudServiceTest.java
+++ b/src/test/java/org/trebol/jpa/services/crud/ProductsJpaCrudServiceTest.java
@@ -103,8 +103,7 @@ class ProductsJpaCrudServiceTest {
     assertEquals(result.getDescription(), productPojoAfterCreation().getDescription());
     assertEquals(result.getCurrentStock(), productPojoAfterCreation().getCurrentStock());
     assertEquals(result.getCriticalStock(), productPojoAfterCreation().getCriticalStock());
-    assertNotNull(result.getImages());
-    assertTrue(result.getImages().isEmpty());
+    assertNull(result.getImages());
     assertNull(result.getCategory());
   }
 

--- a/src/test/java/org/trebol/jpa/services/crud/SalesJpaCrudServiceTest.java
+++ b/src/test/java/org/trebol/jpa/services/crud/SalesJpaCrudServiceTest.java
@@ -109,7 +109,7 @@ class SalesJpaCrudServiceTest {
       throws BadInputException, EntityNotFoundException {
     resetSales();
     Instant updatedDate = Instant.now().minus(Duration.ofHours(1L));
-    SellPojo sellPojoWithUpdates = new SellPojo(sellPojoAfterCreation());
+    SellPojo sellPojoWithUpdates = sellPojoAfterCreation();
     sellPojoWithUpdates.setDate(updatedDate);
     Sell sellEntityWithUpdates = new Sell(sellEntityAfterCreation());
     sellEntityWithUpdates.setDate(updatedDate);
@@ -134,7 +134,7 @@ class SalesJpaCrudServiceTest {
   void returns_same_when_no_update_is_made()
       throws BadInputException, EntityNotFoundException {
     resetSales();
-    SellPojo copy = new SellPojo(sellPojoAfterCreation());
+    SellPojo copy = sellPojoAfterCreation();
     Predicate filters = new BooleanBuilder();
     when(salesRepositoryMock.findOne(filters)).thenReturn(Optional.of(sellEntityAfterCreation()));
     when(salesConverterMock.applyChangesToExistingEntity(copy, sellEntityAfterCreation())).thenReturn(sellEntityAfterCreation());

--- a/src/test/java/org/trebol/jpa/services/crud/SellStatusesJpaCrudServiceTest.java
+++ b/src/test/java/org/trebol/jpa/services/crud/SellStatusesJpaCrudServiceTest.java
@@ -42,11 +42,10 @@ class SellStatusesJpaCrudServiceTest {
     Long statusId = 1L;
     Integer statusCode = 0;
     String statusName = "example sell status name";
-    SellStatusPojo example = new SellStatusPojo(statusName);
     SellStatus persistedEntity = new SellStatus(statusId, statusCode, statusName);
     when(sellStatusesRepositoryMock.findByName(statusName)).thenReturn(Optional.of(persistedEntity));
 
-    Optional<SellStatus> match = instance.getExisting(example);
+    Optional<SellStatus> match = instance.getExisting(SellStatusPojo.builder().name(statusName).build());
 
     assertTrue(match.isPresent());
     assertEquals(match.get().getId(), statusId);

--- a/src/test/java/org/trebol/jpa/services/crud/ShippersJpaCrudServiceTest.java
+++ b/src/test/java/org/trebol/jpa/services/crud/ShippersJpaCrudServiceTest.java
@@ -41,11 +41,10 @@ class ShippersJpaCrudServiceTest {
   void finds_by_name() throws BadInputException {
     Long shipperId = 1L;
     String shipperName = "test-one";
-    ShipperPojo example = new ShipperPojo(shipperName);
     Shipper persistedEntity = new Shipper(shipperId, shipperName);
     when(shippersRepositoryMock.findByName(shipperName)).thenReturn(Optional.of(persistedEntity));
 
-    Optional<Shipper> match = instance.getExisting(example);
+    Optional<Shipper> match = instance.getExisting(ShipperPojo.builder().name(shipperName).build());
 
     assertTrue(match.isPresent());
     assertEquals(match.get().getId(), shipperId);

--- a/src/test/java/org/trebol/jpa/services/crud/UserRolesJpaCrudServiceTest.java
+++ b/src/test/java/org/trebol/jpa/services/crud/UserRolesJpaCrudServiceTest.java
@@ -41,11 +41,10 @@ class UserRolesJpaCrudServiceTest {
   void finds_by_name() throws BadInputException {
     Long roleId = 1L;
     String roleName = "test-role";
-    UserRolePojo example = new UserRolePojo(roleName);
     UserRole persistedEntity = new UserRole(roleId, roleName);
     when(userRolesRepositoryMock.findByName(roleName)).thenReturn(Optional.of(persistedEntity));
 
-    Optional<UserRole> match = instance.getExisting(example);
+    Optional<UserRole> match = instance.getExisting(UserRolePojo.builder().name(roleName).build());
 
     assertTrue(match.isPresent());
     assertEquals(match.get().getId(), roleId);

--- a/src/test/java/org/trebol/jpa/services/crud/UsersJpaCrudServiceTest.java
+++ b/src/test/java/org/trebol/jpa/services/crud/UsersJpaCrudServiceTest.java
@@ -55,11 +55,10 @@ class UsersJpaCrudServiceTest {
     Long roleId = 2L;
     String roleName = "test-role";
     UserRole role = new UserRole(roleId, roleName);
-    UserPojo example = new UserPojo(userName);
     User persistedEntity = new User(userId, userName, userPassword, person, role);
     when(usersRepositoryMock.findByName(userName)).thenReturn(Optional.of(persistedEntity));
 
-    Optional<User> match = instance.getExisting(example);
+    Optional<User> match = instance.getExisting(UserPojo.builder().name(userName).build());
 
     assertTrue(match.isPresent());
     assertEquals(match.get().getId(), userId);
@@ -79,7 +78,6 @@ class UsersJpaCrudServiceTest {
     Long roleId = 2L;
     String roleName = "test-role";
     UserRole role = new UserRole(roleId, roleName);
-    UserPojo example = new UserPojo(userName);
     User userMock = new User(userId, userName, userPassword, person, role);
 
     Predicate predicateMock = new Predicate() {

--- a/src/test/java/org/trebol/operation/services/CheckoutServiceTest.java
+++ b/src/test/java/org/trebol/operation/services/CheckoutServiceTest.java
@@ -41,7 +41,10 @@ class CheckoutServiceTest {
   @Test
   void requests_transaction_start()
       throws BadInputException, PaymentServiceException, EntityNotFoundException {
-    PaymentRedirectionDetailsPojo payload = new PaymentRedirectionDetailsPojo(PAYMENT_URL, SELL_TRANSACTION_TOKEN);
+    PaymentRedirectionDetailsPojo payload = PaymentRedirectionDetailsPojo.builder()
+      .url(PAYMENT_URL)
+      .token(SELL_TRANSACTION_TOKEN)
+      .build();
     resetSales();
     when(paymentIntegrationService.requestNewPaymentPageDetails(sellPojoAfterCreation())).thenReturn(payload);
 
@@ -95,7 +98,10 @@ class CheckoutServiceTest {
   @Test
   void throws_exceptions_at_unexisting_transactions_before_requesting_payments()
       throws PaymentServiceException, EntityNotFoundException, BadInputException {
-    PaymentRedirectionDetailsPojo payload = new PaymentRedirectionDetailsPojo(PAYMENT_URL, SELL_TRANSACTION_TOKEN);
+    PaymentRedirectionDetailsPojo payload = PaymentRedirectionDetailsPojo.builder()
+      .url(PAYMENT_URL)
+      .token(SELL_TRANSACTION_TOKEN)
+      .build();
     String exceptionMessage = "No match";
     resetSales();
     when(paymentIntegrationService.requestNewPaymentPageDetails(sellPojoAfterCreation())).thenReturn(payload);

--- a/src/test/java/org/trebol/operation/services/RegistrationServiceImplTest.java
+++ b/src/test/java/org/trebol/operation/services/RegistrationServiceImplTest.java
@@ -57,7 +57,15 @@ class RegistrationServiceImplTest {
 	@BeforeEach
 	void beforeEach() {
 		// Default mock objects 
-		personPojoMock = mockPersonPojo(1L, "firstName", "lastName", "1", "email@example.com", "+123 456", "+123 456");
+		personPojoMock = PersonPojo.builder()
+      .id(1L)
+      .firstName("firstName")
+      .lastName("lastName")
+      .idNumber("1")
+      .email("email@example.com")
+      .phone1("+123 456")
+      .phone2("+123 456")
+      .build();
 		regPojoMock = mockRegPojo("name", "password", personPojoMock);
 		personMock = mockPerson(1L, "firstName", "lastName", "1", "email@example.com", "+123 456", "+123 456");		
 		customerRoleMock = Optional.of(new UserRole(1L, "Customer"));
@@ -131,11 +139,6 @@ class RegistrationServiceImplTest {
 	}
 	
 	// Helper methods ---
-	
-	PersonPojo mockPersonPojo(Long id, String firstName, String lastName, String idNumber, String email, 
-								String phone1, String phone2) {
-		return new PersonPojo(id, firstName, lastName, idNumber, email, phone1, phone2);				
-	}
 	
 	RegistrationPojo mockRegPojo(String name, String password, PersonPojo personPojo) {
 		RegistrationPojo regPojoMock = new RegistrationPojo();

--- a/src/test/java/org/trebol/testhelpers/CustomersTestHelper.java
+++ b/src/test/java/org/trebol/testhelpers/CustomersTestHelper.java
@@ -33,30 +33,35 @@ public class CustomersTestHelper {
 
   public static CustomerPojo customerPojoForFetch() {
     if (pojoForFetch == null) {
-      pojoForFetch = new CustomerPojo(CUSTOMER_ID_NUMBER);
+      pojoForFetch = CustomerPojo.builder()
+        .person(PersonPojo.builder().idNumber(CUSTOMER_ID_NUMBER).build())
+        .build();
     }
     return pojoForFetch;
   }
 
   public static CustomerPojo customerPojoBeforeCreation() {
     if (pojoBeforeCreation == null) {
-      pojoBeforeCreation = new CustomerPojo(CUSTOMER_ID_NUMBER);
+      pojoForFetch = CustomerPojo.builder()
+        .person(PersonPojo.builder().idNumber(CUSTOMER_ID_NUMBER).build())
+        .build();
     }
     return pojoBeforeCreation;
   }
 
   public static CustomerPojo customerPojoAfterCreation() {
     if (pojoAfterCreation == null) {
-      pojoAfterCreation = new CustomerPojo(
-        PersonPojo.builder()
-          .id(GENERIC_ID)
-          .firstName(CUSTOMER_FIRST_NAME)
-          .lastName(CUSTOMER_LAST_NAME)
-          .idNumber(CUSTOMER_ID_NUMBER)
-          .email(CUSTOMER_EMAIL)
-          .phone1(CUSTOMER_PHONE1)
-          .phone2(CUSTOMER_PHONE2)
-          .build());
+      pojoAfterCreation = CustomerPojo.builder()
+        .person(PersonPojo.builder()
+                  .id(GENERIC_ID)
+                  .firstName(CUSTOMER_FIRST_NAME)
+                  .lastName(CUSTOMER_LAST_NAME)
+                  .idNumber(CUSTOMER_ID_NUMBER)
+                  .email(CUSTOMER_EMAIL)
+                  .phone1(CUSTOMER_PHONE1)
+                  .phone2(CUSTOMER_PHONE2)
+                  .build())
+        .build();
     }
     return pojoAfterCreation;
   }

--- a/src/test/java/org/trebol/testhelpers/CustomersTestHelper.java
+++ b/src/test/java/org/trebol/testhelpers/CustomersTestHelper.java
@@ -47,9 +47,16 @@ public class CustomersTestHelper {
 
   public static CustomerPojo customerPojoAfterCreation() {
     if (pojoAfterCreation == null) {
-      pojoAfterCreation = new CustomerPojo(new PersonPojo(GENERIC_ID, CUSTOMER_FIRST_NAME, CUSTOMER_LAST_NAME,
-                                                          CUSTOMER_ID_NUMBER, CUSTOMER_EMAIL, CUSTOMER_PHONE1,
-                                                          CUSTOMER_PHONE2));
+      pojoAfterCreation = new CustomerPojo(
+        PersonPojo.builder()
+          .id(GENERIC_ID)
+          .firstName(CUSTOMER_FIRST_NAME)
+          .lastName(CUSTOMER_LAST_NAME)
+          .idNumber(CUSTOMER_ID_NUMBER)
+          .email(CUSTOMER_EMAIL)
+          .phone1(CUSTOMER_PHONE1)
+          .phone2(CUSTOMER_PHONE2)
+          .build());
     }
     return pojoAfterCreation;
   }

--- a/src/test/java/org/trebol/testhelpers/ImagesTestHelper.java
+++ b/src/test/java/org/trebol/testhelpers/ImagesTestHelper.java
@@ -28,21 +28,30 @@ public class ImagesTestHelper {
 
   public static ImagePojo imagePojoForFetch() {
     if (pojoForFetch == null) {
-      pojoForFetch = new ImagePojo(IMAGE_FILENAME);
+      pojoForFetch = ImagePojo.builder().filename(IMAGE_FILENAME).build();
     }
     return pojoForFetch;
   }
 
   public static ImagePojo imagePojoBeforeCreation() {
     if (pojoBeforeCreation == null) {
-      pojoBeforeCreation = new ImagePojo(IMAGE_CODE, IMAGE_FILENAME, IMAGE_URL);
+      pojoBeforeCreation = ImagePojo.builder()
+        .code(IMAGE_CODE)
+        .filename(IMAGE_FILENAME)
+        .url(IMAGE_URL)
+        .build();
     }
     return pojoBeforeCreation;
   }
 
   public static ImagePojo imagePojoAfterCreation() {
     if (pojoAfterCreation == null) {
-      pojoAfterCreation = new ImagePojo(IMAGE_ID, IMAGE_CODE, IMAGE_FILENAME, IMAGE_URL);
+      pojoAfterCreation = ImagePojo.builder()
+        .id(IMAGE_ID)
+        .code(IMAGE_CODE)
+        .filename(IMAGE_FILENAME)
+        .url(IMAGE_URL)
+        .build();
     }
     return pojoAfterCreation;
   }

--- a/src/test/java/org/trebol/testhelpers/PeopleTestHelper.java
+++ b/src/test/java/org/trebol/testhelpers/PeopleTestHelper.java
@@ -31,22 +31,29 @@ public class PeopleTestHelper {
 
   public static PersonPojo personPojoForFetch() {
     if (pojoForFetch == null) {
-      pojoForFetch = new PersonPojo(PERSON_ID_NUMBER);
+      pojoForFetch = PersonPojo.builder().idNumber(PERSON_ID_NUMBER).build();
     }
     return pojoForFetch;
   }
 
   public static PersonPojo personPojoBeforeCreation() {
     if (pojoBeforeCreation == null) {
-      pojoBeforeCreation = new PersonPojo(PERSON_ID_NUMBER);
+      pojoBeforeCreation = PersonPojo.builder().idNumber(PERSON_ID_NUMBER).build();
     }
     return pojoBeforeCreation;
   }
 
   public static PersonPojo personPojoAfterCreation() {
     if (pojoAfterCreation == null) {
-      pojoAfterCreation = new PersonPojo(GENERIC_ID, PERSON_FIRST_NAME, PERSON_LAST_NAME, PERSON_ID_NUMBER,
-                                         PERSON_EMAIL, PERSON_PHONE1, PERSON_PHONE2);
+      pojoAfterCreation = PersonPojo.builder()
+        .id(GENERIC_ID)
+        .firstName(PERSON_FIRST_NAME)
+        .lastName(PERSON_LAST_NAME)
+        .idNumber(PERSON_ID_NUMBER)
+        .email(PERSON_EMAIL)
+        .phone1(PERSON_PHONE1)
+        .phone2(PERSON_PHONE2)
+        .build();
     }
     return pojoAfterCreation;
   }

--- a/src/test/java/org/trebol/testhelpers/ProductCategoriesTestHelper.java
+++ b/src/test/java/org/trebol/testhelpers/ProductCategoriesTestHelper.java
@@ -27,21 +27,28 @@ public class ProductCategoriesTestHelper {
 
   public static ProductCategoryPojo productCategoryPojoForFetch() {
     if (pojoForFetch == null) {
-      pojoForFetch = new ProductCategoryPojo(CATEGORY_CODE);
+      pojoForFetch = ProductCategoryPojo.builder().code(CATEGORY_CODE).build();
     }
     return pojoForFetch;
   }
 
   public static ProductCategoryPojo productCategoryPojoBeforeCreation() {
     if (pojoBeforeCreation == null) {
-      pojoBeforeCreation = new ProductCategoryPojo(CATEGORY_CODE, CATEGORY_NAME, null);
+      pojoBeforeCreation = ProductCategoryPojo.builder()
+        .code(CATEGORY_CODE)
+        .name(CATEGORY_NAME)
+        .build();
     }
     return pojoBeforeCreation;
   }
 
   public static ProductCategoryPojo productCategoryPojoAfterCreation() {
     if (pojoAfterCreation == null) {
-      pojoAfterCreation = new ProductCategoryPojo(PRODUCT_ID, CATEGORY_CODE, CATEGORY_NAME, null);
+      pojoAfterCreation = ProductCategoryPojo.builder()
+        .id(PRODUCT_ID)
+        .code(CATEGORY_CODE)
+        .name(CATEGORY_NAME)
+        .build();
     }
     return pojoAfterCreation;
   }

--- a/src/test/java/org/trebol/testhelpers/ProductsTestHelper.java
+++ b/src/test/java/org/trebol/testhelpers/ProductsTestHelper.java
@@ -33,23 +33,36 @@ public class ProductsTestHelper {
 
   public static ProductPojo productPojoForFetch() {
     if (pojoForFetch == null) {
-      pojoForFetch = new ProductPojo(PRODUCT_BARCODE);
+      pojoForFetch = ProductPojo.builder().barcode(PRODUCT_BARCODE).build();
     }
     return pojoForFetch;
   }
 
   public static ProductPojo productPojoBeforeCreation() {
     if (pojoBeforeCreation == null) {
-      pojoBeforeCreation = new ProductPojo(null, PRODUCT_NAME, PRODUCT_BARCODE, PRODUCT_DESCRIPTION, PRODUCT_PRICE,
-                                           PRODUCT_STOCK, PRODUCT_STOCK_CRITICAL, null, List.of());
+      pojoBeforeCreation = ProductPojo.builder()
+        .name(PRODUCT_NAME)
+        .barcode(PRODUCT_BARCODE)
+        .description(PRODUCT_DESCRIPTION)
+        .price(PRODUCT_PRICE)
+        .currentStock(PRODUCT_STOCK)
+        .criticalStock(PRODUCT_STOCK_CRITICAL)
+        .build();
     }
     return pojoBeforeCreation;
   }
 
   public static ProductPojo productPojoAfterCreation() {
     if (pojoAfterCreation == null) {
-      pojoAfterCreation = new ProductPojo(PRODUCT_ID, PRODUCT_NAME, PRODUCT_BARCODE, PRODUCT_DESCRIPTION,
-                                          PRODUCT_PRICE, PRODUCT_STOCK, PRODUCT_STOCK_CRITICAL, null, List.of());
+      pojoAfterCreation = ProductPojo.builder()
+        .id(PRODUCT_ID)
+        .name(PRODUCT_NAME)
+        .barcode(PRODUCT_BARCODE)
+        .description(PRODUCT_DESCRIPTION)
+        .price(PRODUCT_PRICE)
+        .currentStock(PRODUCT_STOCK)
+        .criticalStock(PRODUCT_STOCK_CRITICAL)
+        .build();
     }
     return pojoAfterCreation;
   }

--- a/src/test/java/org/trebol/testhelpers/SalesTestHelper.java
+++ b/src/test/java/org/trebol/testhelpers/SalesTestHelper.java
@@ -44,7 +44,7 @@ public class SalesTestHelper {
 
   public static SellPojo sellPojoForFetch() {
     if (pojoForFetch == null) {
-      pojoForFetch = new SellPojo(GENERIC_ID);
+      pojoForFetch = SellPojo.builder().buyOrder(GENERIC_ID).build();
     }
     return pojoForFetch;
   }
@@ -55,8 +55,12 @@ public class SalesTestHelper {
         .units(SELL_DETAIL_UNITS)
         .product(productPojoBeforeCreation())
         .build();
-      pojoBeforeCreation = new SellPojo(List.of(newDetailPojo), SELL_BILLING_TYPE_NAME_PERSON, SELL_PAYMENT_TYPE_NAME,
-                                        customerPojoBeforeCreation());
+      pojoBeforeCreation = SellPojo.builder()
+        .details(List.of(newDetailPojo))
+        .billingType(SELL_BILLING_TYPE_NAME_PERSON)
+        .paymentType(SELL_PAYMENT_TYPE_NAME)
+        .customer(customerPojoBeforeCreation())
+        .build();
     }
     return pojoBeforeCreation;
   }
@@ -69,11 +73,21 @@ public class SalesTestHelper {
         .unitValue(productPojoAfterCreation().getPrice())
         .product(productPojoAfterCreation())
         .build();
-      pojoAfterCreation = new SellPojo(GENERIC_ID, SELL_TRANSACTION_TOKEN, GENERIC_DATE, List.of(persistedDetailPojo),
-                                       SELL_NET_VALUE, SELL_TAXES_VALUE, SELL_TRANSPORT_VALUE, SELL_TOTAL_VALUE,
-                                       SELL_TOTAL_ITEMS, SELL_STATUS_NAME, SELL_BILLING_TYPE_NAME_PERSON,
-                                       SELL_PAYMENT_TYPE_NAME, customerPojoAfterCreation(), null, null,
-                                       null, null, null);
+      pojoAfterCreation = SellPojo.builder()
+        .buyOrder(GENERIC_ID)
+        .token(SELL_TRANSACTION_TOKEN)
+        .date(GENERIC_DATE)
+        .details(List.of(persistedDetailPojo))
+        .netValue(SELL_NET_VALUE)
+        .taxValue(SELL_TAXES_VALUE)
+        .transportValue(SELL_TRANSPORT_VALUE)
+        .totalValue(SELL_TOTAL_VALUE)
+        .totalValue(SELL_TOTAL_ITEMS)
+        .status(SELL_STATUS_NAME)
+        .billingType(SELL_BILLING_TYPE_NAME_PERSON)
+        .paymentType(SELL_PAYMENT_TYPE_NAME)
+        .customer(customerPojoAfterCreation())
+        .build();
     }
     return pojoAfterCreation;
   }

--- a/src/test/java/org/trebol/testhelpers/SalesTestHelper.java
+++ b/src/test/java/org/trebol/testhelpers/SalesTestHelper.java
@@ -51,7 +51,10 @@ public class SalesTestHelper {
 
   public static SellPojo sellPojoBeforeCreation() {
     if (pojoBeforeCreation == null) {
-      SellDetailPojo newDetailPojo = new SellDetailPojo(SELL_DETAIL_UNITS, productPojoBeforeCreation());
+      SellDetailPojo newDetailPojo = SellDetailPojo.builder()
+        .units(SELL_DETAIL_UNITS)
+        .product(productPojoBeforeCreation())
+        .build();
       pojoBeforeCreation = new SellPojo(List.of(newDetailPojo), SELL_BILLING_TYPE_NAME_PERSON, SELL_PAYMENT_TYPE_NAME,
                                         customerPojoBeforeCreation());
     }
@@ -60,9 +63,12 @@ public class SalesTestHelper {
 
   public static SellPojo sellPojoAfterCreation() {
     if (pojoAfterCreation == null) {
-      SellDetailPojo persistedDetailPojo = new SellDetailPojo(GENERIC_ID, SELL_DETAIL_UNITS,
-                                                              productPojoAfterCreation().getPrice(),
-                                                              productPojoAfterCreation());
+      SellDetailPojo persistedDetailPojo = SellDetailPojo.builder()
+        .id(GENERIC_ID)
+        .units(SELL_DETAIL_UNITS)
+        .unitValue(productPojoAfterCreation().getPrice())
+        .product(productPojoAfterCreation())
+        .build();
       pojoAfterCreation = new SellPojo(GENERIC_ID, SELL_TRANSACTION_TOKEN, GENERIC_DATE, List.of(persistedDetailPojo),
                                        SELL_NET_VALUE, SELL_TAXES_VALUE, SELL_TRANSPORT_VALUE, SELL_TOTAL_VALUE,
                                        SELL_TOTAL_ITEMS, SELL_STATUS_NAME, SELL_BILLING_TYPE_NAME_PERSON,

--- a/src/test/java/org/trebol/testhelpers/SalespeopleTestHelper.java
+++ b/src/test/java/org/trebol/testhelpers/SalespeopleTestHelper.java
@@ -47,9 +47,16 @@ public class SalespeopleTestHelper {
 
   public static SalespersonPojo salespersonPojoAfterCreation() {
     if (pojoAfterCreation == null) {
-      pojoAfterCreation = new SalespersonPojo(new PersonPojo(GENERIC_ID, SALESPERSON_FIRST_NAME, SALESPERSON_LAST_NAME,
-                                                             SALESPERSON_ID_NUMBER, SALESPERSON_EMAIL,
-                                                             SALESPERSON_PHONE1, SALESPERSON_PHONE2));
+      pojoAfterCreation = new SalespersonPojo(
+        PersonPojo.builder()
+          .id(GENERIC_ID)
+          .firstName(SALESPERSON_FIRST_NAME)
+          .lastName(SALESPERSON_LAST_NAME)
+          .idNumber(SALESPERSON_ID_NUMBER)
+          .email(SALESPERSON_EMAIL)
+          .phone1(SALESPERSON_PHONE1)
+          .phone2(SALESPERSON_PHONE2)
+          .build());
     }
     return pojoAfterCreation;
   }

--- a/src/test/java/org/trebol/testhelpers/SalespeopleTestHelper.java
+++ b/src/test/java/org/trebol/testhelpers/SalespeopleTestHelper.java
@@ -33,30 +33,35 @@ public class SalespeopleTestHelper {
 
   public static SalespersonPojo salespersonPojoForFetch() {
     if (pojoForFetch == null) {
-      pojoForFetch = new SalespersonPojo(SALESPERSON_ID_NUMBER);
+      pojoForFetch = SalespersonPojo.builder()
+        .person(PersonPojo.builder().idNumber(SALESPERSON_ID_NUMBER).build())
+        .build();
     }
     return pojoForFetch;
   }
 
   public static SalespersonPojo salespersonPojoBeforeCreation() {
     if (pojoBeforeCreation == null) {
-      pojoBeforeCreation = new SalespersonPojo(SALESPERSON_ID_NUMBER);
+      pojoForFetch = SalespersonPojo.builder()
+        .person(PersonPojo.builder().idNumber(SALESPERSON_ID_NUMBER).build())
+        .build();
     }
     return pojoBeforeCreation;
   }
 
   public static SalespersonPojo salespersonPojoAfterCreation() {
     if (pojoAfterCreation == null) {
-      pojoAfterCreation = new SalespersonPojo(
-        PersonPojo.builder()
-          .id(GENERIC_ID)
-          .firstName(SALESPERSON_FIRST_NAME)
-          .lastName(SALESPERSON_LAST_NAME)
-          .idNumber(SALESPERSON_ID_NUMBER)
-          .email(SALESPERSON_EMAIL)
-          .phone1(SALESPERSON_PHONE1)
-          .phone2(SALESPERSON_PHONE2)
-          .build());
+      pojoAfterCreation = SalespersonPojo.builder()
+        .person(PersonPojo.builder()
+                  .id(GENERIC_ID)
+                  .firstName(SALESPERSON_FIRST_NAME)
+                  .lastName(SALESPERSON_LAST_NAME)
+                  .idNumber(SALESPERSON_ID_NUMBER)
+                  .email(SALESPERSON_EMAIL)
+                  .phone1(SALESPERSON_PHONE1)
+                  .phone2(SALESPERSON_PHONE2)
+                  .build())
+        .build();
     }
     return pojoAfterCreation;
   }


### PR DESCRIPTION
## PR Checklist

- [x] Read the [contribution guidelines](/CONTRIBUTING.md)
- [x] Added a brief description of these changes to the top of the [changelog](/CHANGELOG.md)
- [x] Changes in code meet test criteria (running `mvn test` returns exit code 0, without errors)

## PR Type

- [x] Refactoring (changes that do not affect API nor functionality)

## Summary

Solve issue #151
Add Project Lombok `@Builder` annotation to each pojo class in the project, allowing these to be instantiated and their fields initialized through a clean API.
Originally meant "only" for tests, but as it stands it's a solid way to simplify a lot of instantiation code in all parts of the project (where pojos are concerned).
Constructor methods in Pojos will be replaced with this Builder-based instantiation API.