### PR TITLE
build(github): improve templates [skip ci]

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,45 +1,66 @@
 ---
 name: Bug report
-about: Create a report to help us improve
-title: Cannot do X while Y
+about: Report an error or unexpected behavior
+title: ''
 labels: bug, new
 assignees: ''
 
 ---
 
+<!-- THESE COMMENTS ARE MEANT ONLY FOR YOU TO SEE. PLEASE REMOVE THESE BEFORE SUBMITTING YOUR ISSUE -->
+
 ## Build context
+
+<!-- It is fundamental that you include these, else your bug report could be early-dismissed -->
 
 ### Project version
 
-The current value `<version>` of the version tag in the POM. See file and line number `pom.xml:26`
+<!-- The current value within the `<version>` tags in the `pom.xml` file, in line number 26 -->
 
 ### Latest commits
 
-Please copy and paste the output of `git log` below within code tags. Note that the latest three (3) commits should suffice, no need to scroll further down.
+<!--
+
+Here you can do one of two things
+
+1. Copy and paste the output of `git log -3` below within code tags (). This will print the three (3) latest commits in your current branch
+2. Link to the exact commit that your branch is checked out at
+
+-->
 
 ## Summary
 
-A simple, human-readable description of what the bug is.
+<!-- A simple, human-readable description of the bug -->
 
 ## How to Reproduce
 
-Steps to reproduce the behavior.
+<!--
+
+A list of steps to reproduce the behavior. Such as
 
 1. Run application
 2. Call its API `/some/api/path` with parameters '{...}'
 3. Send payload to API `/some/other/api` with content '{...}'
 4. An error shows up
+5. ???
+6. Profit
+
+-->
 
 ## Expected behavior
 
-A simple description of what you expected to happen.
+<!-- A simple description of what you expected to happen, were it not for this bug. -->
 
 ## Screenshots
+
+<!--
 
 If applicable, add screenshots to help explain your problem.
 
 Please do not post screenshots of plain text, such as console output; instead copy and paste that text, and enclose it within a code block.
 
+-->
+
 ## Additional context
 
-Any other context about the problem here; such as the OS & Browser version. 
+<!-- Any other context about the problem here; such as the OS & Browser version. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,25 +1,36 @@
 ---
 name: Feature request
-about: Suggest an idea for this project
+about: Propose new functionality
 title: ''
 labels: feature, new
 assignees: ''
 
 ---
 
+<!-- THESE COMMENTS ARE MEANT ONLY FOR YOU TO SEE. PLEASE REMOVE THESE BEFORE SUBMITTING YOUR ISSUE -->
+
 ## Summary
 
+<!--
+
 A clear and concise description of what the feature is about.
-You can also give context such as a problematic situation that would be solved by the feature.
+You can also give context such as a problematic situation that would be solved by including the feature.
+
+-->
 
 ### Expected outcome
 
-A clear and concise description of what you want to happen.
+<!-- A clear and concise description of what you want to happen. -->
 
-### Considered alternatives 
+### Considered alternatives
 
-A clear and concise description of any alternative solutions or features you've considered, if any.
+<!--
+
+Describe any solutions or features you've tried to implement or have considered, if any.
+Please give some insight here, even if you haven't done either. It's always useful to understand your train of thought.
+
+-->
 
 ## Additional context
 
-Add any other context or screenshots about the feature request here.
+<!-- You may add any other context about the feature request here; you may delete it. -->

--- a/.github/ISSUE_TEMPLATE/sonar_issue.md
+++ b/.github/ISSUE_TEMPLATE/sonar_issue.md
@@ -1,0 +1,33 @@
+---
+name: Sonar issue
+about: Raise an issue that has been reported by Sonar
+title: '[Sonar] Issue title'
+labels: new
+assignees: ''
+
+---
+
+<!-- THESE COMMENTS ARE MEANT ONLY FOR YOU TO SEE. PLEASE REMOVE THESE BEFORE SUBMITTING YOUR ISSUE -->
+
+## Summary
+
+<!--
+
+All active Sonar issues can be found in this link
+https://sonarcloud.io/project/issues?resolved=false&id=trebol-ecommerce_spring-boot-backend
+
+What really matters here is the source issue URL; make sure you paste it correctly like in the example below
+You can optionally add more information to help us understand the issue at a quick glance
+If not, please remove leftovers, and do not leave any list items below empty
+
+-->
+
+- [Source Sonar issue URL](https://sonarcloud.io/project/issues?issues=AYKvHFl3l4ZcazHMfJ5S&open=AYKvHFl3l4ZcazHMfJ5S&id=trebol-ecommerce_spring-boot-backend)
+
+<!--
+
+- Issue type: `Bug / Vulnerability / Code Smell`
+- Severity: `Blocker / Critical / Major / Minor / Info`
+- Technical debt: `5min / 15min / 20min effort`
+
+-->

--- a/.github/ISSUE_TEMPLATE/test_improvement.md
+++ b/.github/ISSUE_TEMPLATE/test_improvement.md
@@ -1,0 +1,40 @@
+---
+name: Test improvement
+about: Suggest corrections or additional testing for the application
+title: ''
+labels: tests, new
+assignees: ''
+
+---
+
+<!-- THESE COMMENTS ARE MEANT ONLY FOR YOU TO SEE. PLEASE REMOVE THESE BEFORE SUBMITTING YOUR ISSUE -->
+
+## Summary
+
+<!--
+
+A clear description of the testing cases that needs to be added or improved. You can refer to things such as:
+
+- The target Java class or method (or several of them if it applies)
+- Technical context or simple human explanation of the use cases/application flows or events that are involved
+
+If you have several classes, contexts or cases to report, you should try to take advantage of Markdown formatting and separate them into sections accordingly.
+In such situations, an ideal summary would look like this:
+
+```md
+
+### `org.trebol.operation.services.CheckoutServiceImpl`
+
+#### Improve edge cases for method `requestTransactionStart(SellPojo transaction)`
+
+- Behavior not covered by current tests
+  - When a request for inmediate checkout of a new order, is sent without providing the detail items for that order, the request should fail because the service doesn't know the contents of the order
+  - When the same request type is sent without a billing type, the request should fail because the service doesn't know how to bill the customer/user
+- Redundant stubbing
+  - Calls to JPA repositories such as `.findById()` will not be called unless the order is processed first, no need to stub before it happens.
+- Incorrectly tested behavior
+  - A mock service in `org.trebol.operation.services` was confused with a service in `org.trebol.jpa.services` due to their similar method names and signatures. The correct service type must be used.
+
+```
+
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,14 @@
+<!-- THESE COMMENTS ARE MEANT ONLY FOR YOU TO SEE. PLEASE REMOVE THESE BEFORE SUBMITTING YOUR PULL REQUEST -->
+
 ## PR Checklist
 
 - [ ] Read the [contribution guidelines](/CONTRIBUTING.md)
 - [ ] Added a brief description of these changes to the top of the [changelog](/CHANGELOG.md)
 - [ ] Changes in code meet test criteria (running `mvn test` returns exit code 0, without errors)
-- [ ] 
 
 ## PR Type
 
-<!-- Please check only one, remove the others -->
+<!-- Please check only one, and remove the others -->
 
 - [ ] Bugfix
 - [ ] Feature
@@ -19,16 +20,18 @@
 
 ## Summary
 
-Briefly describe the intention behind this PR. 
-
 <!--
+
+Briefly describe the intention behind this PR.
+
 These questions may help you get the right idea
 
 - What areas of interest am I covering here?
 - What is the expected behavior, and how is it different from the previous behavior?
 - How will this contribution help others?
+
 -->
 
 ## Additional info
 
-If you have additional context to provide, such as console output, test edge cases, or anything else worth mentioning, you may include it here.
+<!-- If you have additional context to provide, such as console output, test edge cases, or anything else worth mentioning, you may include it here. -->


### PR DESCRIPTION
## PR Checklist

- [x] Read the [contribution guidelines](/CONTRIBUTING.md)
- [x] Added a brief description of these changes to the top of the [changelog](/CHANGELOG.md) (GITHUB-RELATED CHANGES LIKE THIS DO NOT APPLY)
- [x] Changes in code meet test criteria (running `mvn test` returns exit code 0, without errors)

## PR Type

- [x] Build-related

## Summary

Improve issue and PR templates. Maintainers and new contributors alike should be having a better experience creating new issues and/or PRs with these.

- New template for 'importing' issues reported by Sonar
- New template for requesting more tests
- Updated & cleansed other templates