### PR TITLE
Used entrySet in place of keySet in CorsConfigurationSourceBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `ShipperPojo`
   - `UserPojo`
   - `UserRolePojo`
+- Use entrySet in place of keySet for better iteration in CorsConfigurationSourceBuilder
 
 ### Tests
 

--- a/src/main/java/org/trebol/config/CorsConfigurationSourceBuilder.java
+++ b/src/main/java/org/trebol/config/CorsConfigurationSourceBuilder.java
@@ -53,12 +53,12 @@ public class CorsConfigurationSourceBuilder {
     baseConfig.setAllowCredentials(true);
     baseConfig.setMaxAge(300L);
     UrlBasedCorsConfigurationSource cfg = new UrlBasedCorsConfigurationSource();
-    for (String path : mappings.keySet()) {
-      List<String> methods = Arrays.asList(this.mappings.get(path).split(","));
+    for (Map.Entry<String,String> properties : mappings.entrySet()) {
+      List<String> methods = Arrays.asList(properties.getValue().split(","));
       CorsConfiguration pathConfig = new CorsConfiguration(baseConfig);
       pathConfig.setAllowedOrigins(this.allowedOrigins);
       pathConfig.setAllowedMethods(methods);
-      cfg.registerCorsConfiguration(path, pathConfig);
+      cfg.registerCorsConfiguration(properties.getKey(), pathConfig);
     }
     return cfg;
   }


### PR DESCRIPTION
## PR Checklist

- [x] Read the [contribution guidelines](/CONTRIBUTING.md)
- [x] Added a brief description of these changes to the top of the [changelog](/CHANGELOG.md)
- [x] Changes in code meet test criteria (running `mvn test` returns exit code 0, without errors)

## PR Type

- [x] Refactoring (changes that do not affect API nor functionality)


## Summary

Used entrySet in place of keySet in CorsConfigurationSourceBuilder  which serves better in this purpose when we iterate to get both key and value. Closes #179

