### PR TITLE
Removed  expression that evaluates to "false" Close #217

### DIFF
--- a/src/main/java/org/trebol/jpa/services/crud/BillingTypesJpaCrudServiceImpl.java
+++ b/src/main/java/org/trebol/jpa/services/crud/BillingTypesJpaCrudServiceImpl.java
@@ -52,7 +52,7 @@ public class BillingTypesJpaCrudServiceImpl
   @Override
   public Optional<BillingType> getExisting(BillingTypePojo input) throws BadInputException {
     String name = input.getName();
-    if (name == null || name.isBlank()) {
+    if (name.isBlank()) {
       throw new BadInputException("Billing type has no name");
     } else {
       return billingTypesRepository.findByName(name);


### PR DESCRIPTION
<!-- THESE COMMENTS ARE MEANT ONLY FOR YOU TO SEE. PLEASE REMOVE THESE BEFORE SUBMITTING YOUR PULL REQUEST -->

## PR Checklist

- [x] Read the [contribution guidelines](/CONTRIBUTING.md)
- [x] Added a brief description of these changes to the top of the [changelog](/CHANGELOG.md)
- [x] Changes in code meet test criteria (running `mvn test` returns exit code 0, without errors)

## PR Type

<!-- Please check only one, and remove the others -->

- [x] Bug fix


## Summary

An expression "name == null" was removed. 

As fn getname() cannot return a null, the above expression became redundant in an or statement.

- Code simplification
- Code behavior doesn't change
- simpler to understand


Maven test was run locally, and all 205 tests passed, the build was a success.
